### PR TITLE
Fetch System Time Format for InputTime

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -1,5 +1,7 @@
 #include "AdaptiveCardQmlRenderer.h"
 #include "pch.h"
+#include <windows.h>
+//#include <time.h>
 
 namespace RendererQml
 {
@@ -1108,9 +1110,8 @@ namespace RendererQml
   
 	std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::TimeInputRender(std::shared_ptr<AdaptiveCards::TimeInput> input, std::shared_ptr<AdaptiveRenderContext> context)
 	{
-		//TODO: Fetch System Time Format 
-		bool is12hour = true;
-
+		bool is12hour = Utils::isSystemTime12Hour();
+		
         input->SetId(Utils::ConvertToLowerIdValue(input->GetId()));
 
 		auto uiTimeInput = std::make_shared<QmlTag>("TextField");
@@ -1139,7 +1140,7 @@ namespace RendererQml
 		}
 
 		//TODO: Height Property, Spacing Property
-
+		// Time Format: hh:mm tt -> 03:30 AM or hh:mm -> 15:30 
 		std::string listViewHours_id = id + "_hours";
 		std::string listViewMin_id = id + "_min";
 		std::string listViewtt_id = id + "_tt";

--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -337,25 +337,23 @@ namespace RendererQml
 
 	bool Utils::isSystemTime12Hour()
 	{
-		SYSTEMTIME t;
-		int result;
-		char buffer[30];
+		char dateTimeBuffer[80];
+		struct tm newtime;
+		time_t now = time(0);
+		localtime_s(&newtime, &now);
+		setlocale(LC_TIME, "");
+		strftime(dateTimeBuffer, 80, "%c", &newtime);
 
-		GetLocalTime(&t);
+		std::vector<std::string> time_split = Utils::splitString( std::string(dateTimeBuffer), ' ');
 
-		result = GetTimeFormat(LOCALE_USER_DEFAULT, 0, &t, NULL, (LPTSTR)buffer, sizeof(buffer));
-
-		std::string s = buffer;
-		std::vector<std::string> time_split = Utils::splitString(s, ' ');
-
-		if (result>0 && time_split.size()==1)
+		if (time_split.size() == 2)
 		{
 			return false;
 		}
 		return true;
 	}
 
-	std::vector<std::string> Utils::splitString(std::string& string, char delimiter)
+	std::vector<std::string> Utils::splitString(const std::string& string, char delimiter)
 	{
 		std::vector<std::string> splitElements;
 		std::stringstream ss(string);

--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -1,5 +1,6 @@
 #include "Utils.h"
 #include <time.h>
+#include <windows.h>
 
 namespace RendererQml
 {
@@ -283,15 +284,7 @@ namespace RendererQml
 	std::string Utils::GetTextHighlightColor(std::string textColor)
 	{
 		//input format:rgba(r,g,b,a)
-		std::vector<std::string> color;
-
-		std::stringstream ss(textColor);
-
-		while (ss.good()) {
-			std::string substr;
-			getline(ss, substr, ',');
-			color.push_back(substr);
-		}
+		std::vector<std::string> color = Utils::splitString(textColor, ',');
 
 		auto red=color.front().substr(5);
 		auto opacitystring= color.back().substr(0, color.back().size() - 1);
@@ -304,38 +297,20 @@ namespace RendererQml
 	std::string Utils::GetDate(std::string date, bool MiniumDate_MaximumDate)
 	{
 		//Input format:"yyyy-mm-dd" , Output Format:"mm-dd-yyyy" or "new Date(yyyy,mm,dd)"
-		std::vector<std::string> d;
-
-		std::stringstream ss(date);
-
-		while (ss.good()) 
-		{
-			std::string substr;
-			getline(ss, substr, '-');
-			d.push_back(substr);
-		}
+		std::vector<std::string> date_split = Utils::splitString(date, '-');
 		if (MiniumDate_MaximumDate == true)
 		{
-			return "new Date(" + d[0] + "," + d[1] + "," + d[2] + ")";
+			return "new Date(" + date_split[0] + "," + date_split[1] + "," + date_split[2] + ")";
 		}
-		return d[1] + "-" + d[2] + "-" + d[0];
+		return date_split[1] + "-" + date_split[2] + "-" + date_split[0];
 	}
 
 	bool Utils::isValidTime(std::string& time)
 	{
 		//24 hour format check
-		std::vector<std::string> time_split;
-
-		std::stringstream ss(time);
-
 		try
 		{
-			while (ss.good())
-			{
-				std::string substr;
-				getline(ss, substr, ':');
-				time_split.push_back(substr);
-			}
+			std::vector<std::string> time_split = Utils::splitString(time, ':');
 			if (stoi(time_split[0]) >= 0 && stoi(time_split[0]) <= 23)
 			{
 				if(stoi(time_split[1]) >= 0 && stoi(time_split[1]) <= 59)
@@ -351,21 +326,17 @@ namespace RendererQml
 
 	std::string Utils::defaultTimeto12hour(std::string& defaultTime)
 	{
-		std::vector<std::string> time_split;
+		std::vector<std::string> time_split=Utils::splitString(defaultTime,':');
 
-		std::stringstream ss(defaultTime);
-		while (ss.good())
-		{
-			std::string substr;
-			getline(ss, substr, ':');
-			time_split.push_back(substr);
-		}
 		std::string tt = "AM";
+
 		if (stoi(time_split[0]) > 12)
 		{
 			tt = "PM";
 		}
+
 		time_split[0] = std::to_string(stoi(time_split[0]) > 12 ? stoi(time_split[0]) - 12 : stoi(time_split[0]));
+
 		return Formatter() << std::setfill('0') << std::setw(2) << time_split[0] << ":" << time_split[1] << " " << tt;
 	}
 
@@ -376,5 +347,38 @@ namespace RendererQml
         transform(newId.begin(), newId.end(), newId.begin(), ::tolower);
         return newId;
     }
+
+	bool Utils::isSystemTime12Hour()
+	{
+		SYSTEMTIME t;
+		int result;
+		char buffer[30];
+
+		GetLocalTime(&t);
+
+		result = GetTimeFormat(LOCALE_USER_DEFAULT, 0, &t, NULL, (LPTSTR)buffer, sizeof(buffer));
+
+		std::string s = buffer;
+		std::vector<std::string> time_split = Utils::splitString(s, ' ');
+
+		if (result>0 && time_split.size()==1)
+		{
+			return false;
+		}
+		return true;
+	}
+
+	std::vector<std::string> Utils::splitString(std::string& string, char delimiter)
+	{
+		std::vector<std::string> splitElements;
+		std::stringstream ss(string);
+		while (ss.good())
+		{
+			std::string substr;
+			getline(ss, substr, delimiter);
+			splitElements.push_back(substr);
+		}
+		return splitElements;
+	}
 
 }

--- a/source/qml/Library/RendererQml/Utils.h
+++ b/source/qml/Library/RendererQml/Utils.h
@@ -110,6 +110,10 @@ namespace RendererQml
 
         static std::string ConvertToLowerIdValue(const std::string& value);
 
+		static bool isSystemTime12Hour();
+
+		static std::vector<std::string> splitString(std::string& string, char delimiter);
+
     private:
         Utils() {}
     };

--- a/source/qml/Library/RendererQml/Utils.h
+++ b/source/qml/Library/RendererQml/Utils.h
@@ -110,7 +110,7 @@ namespace RendererQml
 
 		static bool isSystemTime12Hour();
 
-		static std::vector<std::string> splitString(std::string& string, char delimiter);
+		static std::vector<std::string> splitString(const std::string& string, char delimiter);
 
     private:
         Utils() {}


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Added a function that fetches the time format of the user's system which is used to switch between the 12-hour and the 24-hour format InputTime

## Sample Card
24 Hour Format
![image](https://user-images.githubusercontent.com/78541663/110452292-0e44ec80-80eb-11eb-80f1-1d53130ae8d6.png)

12 Hour Format
![image](https://user-images.githubusercontent.com/78541663/110452782-80b5cc80-80eb-11eb-90d7-9606b9b9dcc6.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
