### PR TITLE
[MacOS] ColumnSet Renderer Properties and other fixes

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/SampleColumnSetChoiceSet.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/SampleColumnSetChoiceSet.json
@@ -1,0 +1,190 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": "Add Reports To Space"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "choices": [
+                {
+                    "title": "All Reports",
+                    "value": "1"
+                },
+                {
+                    "title": "Direct Reports",
+                    "value": "2"
+                }
+            ],
+            "placeholder": "Please choose type of report (all or direct)",
+            "id": "report"
+        },
+        {
+            "type": "Input.Toggle",
+            "title": "Include all employee types",
+            "id": "all_employees",
+            "value": "false",
+            "wrap": false
+        },
+        {
+            "type": "TextBlock",
+            "text": "Or choose specific types:",
+            "wrap": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Full-time",
+                                    "value": "1"
+                                },
+                                {
+                                    "title": "Hourly",
+                                    "value": "2"
+                                },
+                                {
+                                    "title": "Agency",
+                                    "value": "3"
+                                }
+                            ],
+                            
+                            "id": "employee_1",
+                            "isMultiSelect": true,
+                            "style": "expanded",
+                            
+                            "wrap": true,
+                            "spacing": "None"
+                        }
+                    ],
+                    
+                    "style": "default",
+                    "spacing": "None"
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Joint Venture",
+                                    "value": "4"
+                                },
+                                {
+                                    "title": "Part-time",
+                                    "value": "5"
+                                },
+                                {
+                                    "title": "New Employee",
+                                    "value": "6"
+                                }
+                            ],
+                            
+                            "isMultiSelect": true,
+                            "id": "employee_2",
+                            "wrap": true,
+                            "style": "expanded",
+                            "spacing": "None"
+                        }
+                    ],
+                    
+                    "style": "default",
+                    "spacing": "None"
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Subsidiary",
+                                    "value": "7"
+                                },
+                                {
+                                    "title": "Supplier",
+                                    "value": "8"
+                                }
+                            ],
+                            
+                            "isMultiSelect": true,
+                            "id": "employee_3",
+                            "style": "expanded",
+                            "wrap": true,
+                            "spacing": "None"
+                        }
+                    ],
+                    
+                    "style": "default",
+                    "spacing": "None"
+                }
+            ],
+            "spacing": "None"
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.2",
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Submit",
+            "style": "positive",
+            "id": "submit"
+        },
+        {
+            "type": "Action.Submit",
+            "title": "Cancel",
+            "id": "cancel",
+            "style": "destructive"
+        },
+        {
+            "type": "Action.ShowCard",
+            "title": "Help",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "TextBlock",
+                        "text": "How to use:",
+                        "wrap": true,
+                        "weight": "Bolder"
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": "To add reports to a space, select \"Direct\" or \"All\" from the dropdown menu. Then either choose to include all employee types or specify individual classifications using the checkboxes. Click Submit, and the bot will add your direct reports to the space.",
+                        "wrap": true
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": "Employee Types Key:",
+                        "wrap": true,
+                        "weight": "Bolder"
+                    },
+                    {
+                        "type": "RichTextBlock",
+                        "inlines": [
+                            {
+                                "type": "TextRun",
+                                "text": "F - Ford Full-time Salaried \nH - Ford Hourly \nA - Agency/Contractor \nJ - Ford Joint Venture \nP - Ford Part-time \nN - Ford Full-time salaried, Part-time, or Hourly \nW - Ford Wholly Owned Subsidiary \nM - Non-production Supplier"
+                            }
+                        ]
+                    }
+                ],
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+            },
+            "id": "help"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		0801D5CE25C27AC100AABD6C /* libAdaptiveCards-shared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 08E403B125B46A2600C2092A /* libAdaptiveCards-shared.a */; };
 		0801D5DD25C27E3100AABD6C /* BridgeConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 089DC8D525B856DA00626E8F /* BridgeConverter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0801D5EA25C2C3B500AABD6C /* AdaptiveCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801D5D825C27D4900AABD6C /* AdaptiveCard.swift */; };
+		0801EDB425F78EB800D64C86 /* FakeColumnSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801EDB325F78EB800D64C86 /* FakeColumnSet.swift */; };
+		0801EDB925F78EC800D64C86 /* FakeColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801EDB825F78EC800D64C86 /* FakeColumn.swift */; };
+		0801EDBE25F7913300D64C86 /* ColumnSetRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801EDBD25F7913300D64C86 /* ColumnSetRendererTests.swift */; };
+		0801EDC325F7914200D64C86 /* ColumnRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801EDC225F7914200D64C86 /* ColumnRendererTests.swift */; };
 		082864D625C977600080D767 /* AdaptiveCards_bridge-BridgingHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 082864D525C977600080D767 /* AdaptiveCards_bridge-BridgingHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		082864FD25C99E300080D767 /* HostConfigUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082864FC25C99E300080D767 /* HostConfigUtils.swift */; };
 		08299E3925AF254000799C66 /* AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08299E2F25AF254000799C66 /* AdaptiveCards.framework */; };
@@ -515,6 +519,10 @@
 
 /* Begin PBXFileReference section */
 		0801D5D825C27D4900AABD6C /* AdaptiveCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveCard.swift; sourceTree = "<group>"; };
+		0801EDB325F78EB800D64C86 /* FakeColumnSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeColumnSet.swift; sourceTree = "<group>"; };
+		0801EDB825F78EC800D64C86 /* FakeColumn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeColumn.swift; sourceTree = "<group>"; };
+		0801EDBD25F7913300D64C86 /* ColumnSetRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnSetRendererTests.swift; sourceTree = "<group>"; };
+		0801EDC225F7914200D64C86 /* ColumnRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnRendererTests.swift; sourceTree = "<group>"; };
 		082864D525C977600080D767 /* AdaptiveCards_bridge-BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AdaptiveCards_bridge-BridgingHeader.h"; sourceTree = "<group>"; };
 		082864FC25C99E300080D767 /* HostConfigUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConfigUtils.swift; sourceTree = "<group>"; };
 		08299E2F25AF254000799C66 /* AdaptiveCards.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AdaptiveCards.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1242,6 +1250,8 @@
 				13B13E4B25E750CB005D9380 /* FakeInputDate.swift */,
 				13C41B0825F257C2008A1F2E /* FakeInputTime.swift */,
 				29F712ED25F73A360052DC41 /* FakeContainer.swift */,
+				0801EDB325F78EB800D64C86 /* FakeColumnSet.swift */,
+				0801EDB825F78EC800D64C86 /* FakeColumn.swift */,
 			);
 			path = Fakes;
 			sourceTree = "<group>";
@@ -1261,6 +1271,8 @@
 				13B13E4D25E75239005D9380 /* InputDateRendererTests.swift */,
 				13C41B0A25F25836008A1F2E /* InputTimeRendererTests.swift */,
 				29F712F225F750F30052DC41 /* ContainerRendererTests.swift */,
+				0801EDBD25F7913300D64C86 /* ColumnSetRendererTests.swift */,
+				0801EDC225F7914200D64C86 /* ColumnRendererTests.swift */,
 			);
 			path = Renderers;
 			sourceTree = "<group>";
@@ -2137,12 +2149,15 @@
 				2871B16625DF722A0040AB27 /* MultilineInputTextRendererTest.swift in Sources */,
 				29E8DF8A25E8223D000EC12F /* FakeChoiceInput.swift in Sources */,
 				13B13E4C25E750CB005D9380 /* FakeInputDate.swift in Sources */,
+				0801EDBE25F7913300D64C86 /* ColumnSetRendererTests.swift in Sources */,
 				082D912B25D67042000226C4 /* FakeHostConfig.swift in Sources */,
 				A04EA82425F00C6100C4C7DB /* ImageRendererTests.swift in Sources */,
 				29E8DF8025E7C567000EC12F /* FakeChoiceSetInput.swift in Sources */,
 				A04EA82925F00F3400C4C7DB /* FakeImageView.swift in Sources */,
+				0801EDC325F7914200D64C86 /* ColumnRendererTests.swift in Sources */,
 				29050C4225DAAD9300AF3CA9 /* InputToggleRendererTests.swift in Sources */,
 				28CE1A7525E4F24F00BFCFD9 /* FakeFacts.swift in Sources */,
+				0801EDB425F78EB800D64C86 /* FakeColumnSet.swift in Sources */,
 				2871B15025DD4C4D0040AB27 /* TextInputRedererTest.swift in Sources */,
 				28CE1A6B25E4B67B00BFCFD9 /* FakeFactSet.swift in Sources */,
 				082D914425D6DC7A000226C4 /* FakeTextBlock.swift in Sources */,
@@ -2157,6 +2172,7 @@
 				29E8DF8525E81E5A000EC12F /* ChoiceSetInputRendererTests.swift in Sources */,
 				13C41B0925F257C3008A1F2E /* FakeInputTime.swift in Sources */,
 				2871B13F25DD41D80040AB27 /* InputNumberRendererTest.swift in Sources */,
+				0801EDB925F78EC800D64C86 /* FakeColumn.swift in Sources */,
 				A0805F5825E40CB400B3F8EA /* RichTextBlockRendererTest.swift in Sources */,
 				13B13E4E25E75239005D9380 /* InputDateRendererTests.swift in Sources */,
 				13C41B0B25F25836008A1F2E /* InputTimeRendererTests.swift in Sources */,

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -7,28 +7,7 @@ class BaseCardElementRenderer {
         
         // For Spacing
         if !isfirstElement {
-            let spacingConfig = hostConfig.getSpacing()
-            let spaceAdded: NSNumber
-            switch element.getSpacing() {
-            case .default:
-                spaceAdded = spacingConfig?.defaultSpacing ?? 0
-            case .none:
-                spaceAdded = 0
-            case .small:
-                spaceAdded = spacingConfig?.smallSpacing ?? 3
-            case .medium:
-                spaceAdded = spacingConfig?.mediumSpacing ?? 20
-            case .large:
-                spaceAdded = spacingConfig?.largeSpacing ?? 30
-            case .extraLarge:
-                spaceAdded = spacingConfig?.extraLargeSpacing ?? 40
-            case .padding:
-                spaceAdded = spacingConfig?.paddingSpacing ?? 20
-            @unknown default:
-                logError("Unknown padding!")
-                spaceAdded = 0
-            }
-            updatedView.addSpacing(spacing: CGFloat(truncating: spaceAdded))
+            updatedView.addSpacing(element.getSpacing())
         }
         
         if let elem = element as? ACSImage {
@@ -41,10 +20,7 @@ class BaseCardElementRenderer {
         
         // For seperator
         if element.getSeparator(), !isfirstElement {
-            let seperatorConfig = hostConfig.getSeparator()
-            let lineThickness = seperatorConfig?.lineThickness
-            let lineColor = seperatorConfig?.lineColor
-            updatedView.addSeperator(thickness: lineThickness ?? 1, color: lineColor ?? "#EEEEEE")
+            updatedView.addSeperator(true)
         }
         
         view.identifier = .init(element.getId() ?? "")
@@ -59,8 +35,9 @@ class BaseCardElementRenderer {
             let labelView = NSTextField(labelWithAttributedString: attributedString)
             labelView.isEditable = false
             updatedView.addArrangedSubview(labelView)
-            updatedView.setCustomSpacing(spacing: 3, view: labelView)
+            updatedView.setCustomSpacing(spacing: 3, after: labelView)
         }
+        
         updatedView.addArrangedSubview(view)
         if view is ACRContentStackView {
             view.widthAnchor.constraint(equalTo: updatedView.widthAnchor).isActive = true

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -13,12 +13,18 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         let columnView = ACRColumnView(style: style, hostConfig: hostConfig)
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
+//        columnView.setStyle(column.getStyle(), parentStyle: style)
         
         for item in column.getItems() {
             let renderer = RendererManager.shared.renderer(for: item.getType())
             let view = renderer.render(element: item, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [])
             columnView.addArrangedSubview(view)
         }
+        
+        if let height = column.getMinHeight(), let heightPt = CGFloat(exactly: height), heightPt > 0 {
+            columnView.heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
+        }
+        
         return columnView
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -13,7 +13,6 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView)
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
-//        columnView.setStyle(column.getStyle(), parentStyle: style)
         
         var topSpacingView: NSView?
         if column.getVerticalContentAlignment() == .center || column.getVerticalContentAlignment() == .bottom {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -15,10 +15,25 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
 //        columnView.setStyle(column.getStyle(), parentStyle: style)
         
+        var topSpacingView: NSView?
+        if column.getVerticalContentAlignment() == .center || column.getVerticalContentAlignment() == .bottom {
+            let view = NSView()
+            columnView.addArrangedSubview(view)
+            topSpacingView = view
+        }
+        
         for item in column.getItems() {
             let renderer = RendererManager.shared.renderer(for: item.getType())
             let view = renderer.render(element: item, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [])
             columnView.addArrangedSubview(view)
+        }
+        
+        if column.getVerticalContentAlignment() == .center, let topView = topSpacingView {
+            let view = NSView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            topView.translatesAutoresizingMaskIntoConstraints = false
+            columnView.addArrangedSubview(view)
+            view.heightAnchor.constraint(equalTo: topView.heightAnchor).isActive = true
         }
         
         if let height = column.getMinHeight(), let heightPt = CGFloat(exactly: height), heightPt > 0 {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -10,7 +10,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let columnView = ACRColumnView(style: style, hostConfig: hostConfig)
+        let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView)
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
 //        columnView.setStyle(column.getStyle(), parentStyle: style)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -46,18 +46,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         // Only one is weighted and others are stretch
         let isSpecialAllStretch = numberOfWeightedItems == 1 && numberOfStretchItems == totalColumns - 1
         
-        let totalAvailableWeight = getTotalAvailableWeight(from: columnSet.getColumns())
-        if numberOfWeightedItems == totalColumns {
-            columnSetView.distribution = .fill
-            for (index, column) in columnSet.getColumns().enumerated() {
-                guard let width = column.getWidth(), let weight = Int(width), index < columnSetView.arrangedSubviews.count else {
-                    logError("Expected a weighted column here.")
-                    continue
-                }
-                let columnView = columnSetView.arrangedSubviews[index]
-                columnView.widthAnchor.constraint(equalTo: columnSetView.widthAnchor, multiplier: CGFloat(weight) / CGFloat(totalAvailableWeight)).isActive = true
-            }
-        } else if numberOfStretchItems == totalColumns || isSpecialAllStretch {
+        if numberOfStretchItems == totalColumns || isSpecialAllStretch {
             columnSetView.distribution = .fillEqually
         } else if numberOfAutoItems == totalColumns {
             columnSetView.distribution = .gravityAreas

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -17,11 +17,14 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
         
         // Create stacks to hold title and value of FactSet
         let titleStack = NSStackView()
-        let valueStack = NSStackView()
-        titleStack.orientation = .vertical
-        valueStack.orientation = .vertical
         titleStack.translatesAutoresizingMaskIntoConstraints = false
+        titleStack.orientation = .vertical
+        titleStack.alignment = .leading
+        
+        let valueStack = NSStackView()
         valueStack.translatesAutoresizingMaskIntoConstraints = false
+        valueStack.orientation = .vertical
+        valueStack.alignment = .leading
         
         // Main loop to iterate over Array of facts
         for fact in factArray {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -70,7 +70,9 @@ class ACRTextView: NSTextView {
             return super.intrinsicContentSize
         }
         layoutManager.ensureLayout(for: textContainer)
-        return layoutManager.usedRect(for: textContainer).size
+        let size = layoutManager.usedRect(for: textContainer).size
+        let width = size.width + 10
+        return NSSize(width: width, height: size.height)
     }
     
     override func viewDidMoveToSuperview() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -71,7 +71,7 @@ class ACRTextView: NSTextView {
         }
         layoutManager.ensureLayout(for: textContainer)
         let size = layoutManager.usedRect(for: textContainer).size
-        let width = size.width + 10
+        let width = size.width + 2
         return NSSize(width: width, height: size.height)
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
@@ -18,6 +18,22 @@ extension ACSHostConfig {
         }
         return ColorUtils.color(from: hexColorCode)
     }
+    
+    func getBorderColor(for containerStyle: ACSContainerStyle) -> NSColor? {
+        guard let hexColorCode = getBorderColor(containerStyle) else {
+            logError("HexColorCode is nil")
+            return nil
+        }
+        return ColorUtils.color(from: hexColorCode)
+    }
+    
+    func getBorderThickness(for containerStyle: ACSContainerStyle) -> CGFloat? {
+        guard let thickness = getBorderThickness(containerStyle) else {
+            logError("HexColorCode is nil")
+            return nil
+        }
+        return CGFloat(exactly: thickness)
+    }
 }
 
 class FontUtils {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -54,28 +54,6 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
             layer?.backgroundColor = bgColor.cgColor
         }
     }
-    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle, hostConfig: ACSHostConfig, superview: NSView) {
-        super.init(frame: .zero)
-        initialize()
-        wantsLayer = true
-        if style != .none {
-            if let bgColor = hostConfig.getBackgroundColor(for: style) {
-                layer?.backgroundColor = bgColor.cgColor
-            }
-            // set border color
-            if let borderColorHex = hostConfig.getBorderColor(style), let borderColor = ColorUtils.color(from: borderColorHex) {
-                layer?.borderColor = borderColor.cgColor
-            }
-            // set border width
-            if let borderWidth = hostConfig.getBorderThickness(style) {
-                layer?.borderWidth = CGFloat(truncating: borderWidth)
-            }
-            // add padding
-            if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-                applyPadding(padding)
-            }
-        }
-    }
     
     init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?) {
         self.hostConfig = hostConfig
@@ -241,11 +219,6 @@ class ACRColumnView: ACRContentStackView {
         initialize()
     }
     
-    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle, hostConfig: ACSHostConfig, superview: NSView) {
-        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview)
-        initialize()
-    }
-    
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         initialize()
@@ -270,22 +243,6 @@ class ACRColumnView: ACRContentStackView {
         columnWidth = width
         manageWidth(of: self)
         manageWidth(of: stackView)
-    }
-    
-    func setStyle(_ style: ACSContainerStyle, parentStyle: ACSContainerStyle?) {
-        guard style != .none, style != parentStyle else { return }
-        if let bgColor = hostConfig.getBackgroundColor(for: style) {
-            layer?.backgroundColor = bgColor.cgColor
-        }
-        if let borderColor = hostConfig.getBorderColor(for: style) {
-            layer?.borderColor = borderColor.cgColor
-        }
-        if let borderWidth = hostConfig.getBorderThickness(for: style) {
-            layer?.borderWidth = borderWidth
-        }
-        if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-            applyPadding(padding)
-        }
     }
     
     private func manageWidth(of view: NSView) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -12,6 +12,8 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
     private (set) var stackViewTopConstraint: NSLayoutConstraint?
     private (set) var stackViewBottomConstraint: NSLayoutConstraint?
     
+    let hostConfig: ACSHostConfig
+    
     public var orientation: NSUserInterfaceLayoutOrientation {
         get { return stackView.orientation }
         set {
@@ -44,6 +46,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
     }()
     
     init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
+        self.hostConfig = hostConfig
         super.init(frame: .zero)
         initialize()
         wantsLayer = true
@@ -75,6 +78,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
     }
     
     required init?(coder: NSCoder) {
+        self.hostConfig = ACSHostConfig() // TODO: This won't work
         super.init(coder: coder)
         initialize()
     }
@@ -95,26 +99,53 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
         stackViewBottomConstraint?.constant = -padding
     }
     
-    func addSeperator(thickness: NSNumber, color: String) {
+    func addSeperator(_ separator: Bool) {
+        guard separator else { return }
+        let seperatorConfig = hostConfig.getSeparator()
+        let lineThickness = seperatorConfig?.lineThickness
+        let lineColor = seperatorConfig?.lineColor
+        addSeperator(thickness: lineThickness ?? 1, color: lineColor ?? "#EEEEEE")
+    }
+    
+    func addSpacing(_ spacing: ACSSpacing) {
+        let spacingConfig = hostConfig.getSpacing()
+        let spaceAdded: NSNumber
+        switch spacing {
+        case .default: spaceAdded = spacingConfig?.defaultSpacing ?? 0
+        case .none: spaceAdded = 0
+        case .small: spaceAdded = spacingConfig?.smallSpacing ?? 3
+        case .medium: spaceAdded = spacingConfig?.mediumSpacing ?? 20
+        case .large: spaceAdded = spacingConfig?.largeSpacing ?? 30
+        case .extraLarge: spaceAdded = spacingConfig?.extraLargeSpacing ?? 40
+        case .padding: spaceAdded = spacingConfig?.paddingSpacing ?? 20
+        @unknown default:
+            logError("Unknown padding!")
+            spaceAdded = 0
+        }
+        addSpacing(spacing: CGFloat(truncating: spaceAdded))
+    }
+    
+    func setCustomSpacing(spacing: CGFloat, after view: NSView) {
+        stackView.setCustomSpacing(spacing, after: view)
+    }
+    
+    private func addSeperator(thickness: NSNumber, color: String) {
         let seperatorView = NSBox()
         seperatorView.boxType = .custom
-        seperatorView.heightAnchor.constraint(equalToConstant: CGFloat(truncating: thickness)).isActive = true
+        let anchor = orientation == .horizontal ? seperatorView.widthAnchor : seperatorView.heightAnchor
+        anchor.constraint(equalToConstant: CGFloat(truncating: thickness)).isActive = true
         seperatorView.borderColor = ColorUtils.color(from: color) ?? .black
         stackView.addArrangedSubview(seperatorView)
         stackView.setCustomSpacing(3, after: seperatorView)
     }
     
-    func addSpacing(spacing: CGFloat) {
+    private func addSpacing(spacing: CGFloat) {
         let spacingView = NSBox()
         spacingView.boxType = .custom
         let anchor = orientation == .horizontal ? spacingView.widthAnchor : spacingView.heightAnchor
         anchor.constraint(equalToConstant: spacing).isActive = true
         spacingView.borderColor = .clear
         stackView.addArrangedSubview(spacingView)
-    }
-    
-    func setCustomSpacing(spacing: CGFloat, view: NSView) {
-        stackView.setCustomSpacing(spacing, after: view)
     }
     
     private func setupViews() {
@@ -215,6 +246,22 @@ class ACRColumnView: ACRContentStackView {
         columnWidth = width
         manageWidth(of: self)
         manageWidth(of: stackView)
+    }
+    
+    func setStyle(_ style: ACSContainerStyle, parentStyle: ACSContainerStyle?) {
+        guard style != .none, style != parentStyle else { return }
+        if let bgColor = hostConfig.getBackgroundColor(for: style) {
+            layer?.backgroundColor = bgColor.cgColor
+        }
+        if let borderColor = hostConfig.getBorderColor(for: style) {
+            layer?.borderColor = borderColor.cgColor
+        }
+        if let borderWidth = hostConfig.getBorderThickness(for: style) {
+            layer?.borderWidth = borderWidth
+        }
+        if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
+            applyPadding(padding)
+        }
     }
     
     private func manageWidth(of view: NSView) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -77,6 +77,30 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol {
         }
     }
     
+    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?) {
+        self.hostConfig = hostConfig
+        super.init(frame: .zero)
+        initialize()
+        wantsLayer = true
+        if style != .none {
+            if let bgColor = hostConfig.getBackgroundColor(for: style) {
+                layer?.backgroundColor = bgColor.cgColor
+            }
+            // set border color
+            if let borderColorHex = hostConfig.getBorderColor(style), let borderColor = ColorUtils.color(from: borderColorHex) {
+                layer?.borderColor = borderColor.cgColor
+            }
+            // set border width
+            if let borderWidth = hostConfig.getBorderThickness(style) {
+                layer?.borderWidth = CGFloat(truncating: borderWidth)
+            }
+            // add padding
+            if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
+                applyPadding(padding)
+            }
+        }
+    }
+    
     required init?(coder: NSCoder) {
         self.hostConfig = ACSHostConfig() // TODO: This won't work
         super.init(coder: coder)
@@ -210,10 +234,10 @@ class ACRColumnView: ACRContentStackView {
     }
     
     private lazy var widthConstraint = widthAnchor.constraint(equalToConstant: Constants.minWidth)
-    private var columnWidth: ColumnWidth = .weighted(1)
+    private (set) var columnWidth: ColumnWidth = .weighted(1)
     
-    override init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
-        super.init(style: style, hostConfig: hostConfig)
+    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?) {
+        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview)
         initialize()
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRFactTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRFactTextField.swift
@@ -60,13 +60,6 @@ class ACRFactTextField: NSView {
         get { return labelTextField.stringValue }
         set { labelTextField.stringValue = newValue ?? "" }
     }
-    
-    override func viewDidMoveToSuperview() {
-        super.viewDidMoveToSuperview()
-        // Should look for better solution
-        guard let superview = superview else { return }
-        widthAnchor.constraint(equalTo: superview.widthAnchor).isActive = true
-    }
 }
 
 // MARK: Class required for Horizontal Stack View

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -2,8 +2,8 @@ import AdaptiveCards_bridge
 import AppKit
 
 class ACRView: ACRColumnView {
-    override init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
-        super.init(style: style, hostConfig: hostConfig)
+    init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
+        super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil)
         setStyle(style, parentStyle: nil)
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -4,19 +4,10 @@ import AppKit
 class ACRView: ACRColumnView {
     override init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
         super.init(style: style, hostConfig: hostConfig)
-        if let paddingSpace = hostConfig.getSpacing()?.paddingSpacing, let padding = CGFloat(exactly: paddingSpace) {
-            applyPadding(padding)
-        }
+        setStyle(style, parentStyle: nil)
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-    }
-    
-    override func addArrangedSubview(_ subview: NSView) {
-        super.addArrangedSubview(subview)
-        if subview is ACRContentStackView {
-            subview.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
-        }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -4,7 +4,6 @@ import AppKit
 class ACRView: ACRColumnView {
     init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
         super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil)
-        setStyle(style, parentStyle: nil)
     }
     
     required init?(coder: NSCoder) {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
@@ -1,0 +1,97 @@
+import AdaptiveCards_bridge
+
+class FakeColumn: ACSColumn {
+    var width: String?
+    var pixelWidth: NSNumber?
+    var items: [ACSBaseCardElement] = []
+    var style: ACSContainerStyle = .default
+    var verticalContentAlignment: ACSVerticalContentAlignment = .top
+    var minHeight: NSNumber?
+    var bleed: Bool = false
+    var spacing: ACSSpacing = .default
+    var separator: Bool = false
+    
+    override func getWidth() -> String? {
+        return width
+    }
+    
+    override func setWidth(_ value: String) {
+        width = value
+    }
+    
+    override func getPixelWidth() -> NSNumber? {
+        return pixelWidth
+    }
+    
+    override func setPixelWidth(_ value: NSNumber) {
+        pixelWidth = value
+    }
+    
+    override func getItems() -> [ACSBaseCardElement] {
+        return items
+    }
+    
+    override func getStyle() -> ACSContainerStyle {
+        return style
+    }
+    
+    override func setStyle(_ value: ACSContainerStyle) {
+        style = value
+    }
+    
+    override func getVerticalContentAlignment() -> ACSVerticalContentAlignment {
+        return verticalContentAlignment
+    }
+    
+    override func setVerticalContentAlignment(_ value: ACSVerticalContentAlignment) {
+        verticalContentAlignment = value
+    }
+    
+    override func getMinHeight() -> NSNumber? {
+        return minHeight
+    }
+    
+    override func setMinHeight(_ value: NSNumber) {
+        minHeight = value
+    }
+    
+    override func getBleed() -> Bool {
+        return bleed
+    }
+    
+    override func setBleed(_ value: Bool) {
+        bleed = value
+    }
+    
+    override func getSpacing() -> ACSSpacing {
+        return spacing
+    }
+    
+    override func setSpacing(_ value: ACSSpacing) {
+        spacing = value
+    }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func setSeparator(_ value: Bool) {
+        separator = value
+    }
+}
+
+extension FakeColumn {
+    static func make(width: String? = "", pixelWidth: NSNumber? = 0, items: [ACSBaseCardElement] = [], style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, minHeight: NSNumber? = nil, bleed: Bool = false, spacing: ACSSpacing = .default, separator: Bool = false) -> FakeColumn {
+        let fakeColumn = FakeColumn()
+        fakeColumn.width = width
+        fakeColumn.pixelWidth = pixelWidth
+        fakeColumn.items = items
+        fakeColumn.style = style
+        fakeColumn.verticalContentAlignment = verticalContentAlignment
+        fakeColumn.minHeight = minHeight
+        fakeColumn.bleed = bleed
+        fakeColumn.spacing = spacing
+        fakeColumn.separator = separator
+        return fakeColumn
+    }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
@@ -1,0 +1,27 @@
+import AdaptiveCards_bridge
+
+class FakeColumnSet: ACSColumnSet {
+    var columns: [ACSColumn] = []
+    var style: ACSContainerStyle = .default
+    
+    override func getColumns() -> [ACSColumn] {
+        return columns
+    }
+    
+    override func getStyle() -> ACSContainerStyle {
+        return style
+    }
+    
+    override func setStyle(_ value: ACSContainerStyle) {
+        style = value
+    }
+}
+
+extension FakeColumnSet {
+    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default) -> FakeColumnSet {
+        let fakeColumnSet = FakeColumnSet()
+        fakeColumnSet.columns = columns
+        fakeColumnSet.style = style
+        return fakeColumnSet
+    }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputNumber.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputNumber.swift
@@ -46,6 +46,10 @@ class FakeInputNumber: ACSNumberInput {
     override func setIsVisible(_ value: Bool) {
         isVisible = value
     }
+    
+    override func getType() -> ACSCardElementType {
+        return .numberInput
+    }
 }
 
 extension FakeInputNumber {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextBlock.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextBlock.swift
@@ -96,6 +96,10 @@ class FakeTextBlock: ACSTextBlock {
     open override func getLanguage() -> String? {
         return language
     }
+    
+    open override func getType() -> ACSCardElementType {
+        return .textBlock
+    }
 }
 
 extension FakeTextBlock {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -1,0 +1,78 @@
+@testable import AdaptiveCards
+import AdaptiveCards_bridge
+import XCTest
+
+class ColumnRendererTests: XCTestCase {
+    private var hostConfig: FakeHostConfig!
+    private var column: FakeColumn!
+    private var columnRenderer: ColumnRenderer!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        hostConfig = .make()
+        column = .make()
+        columnRenderer = ColumnRenderer()
+    }
+    
+    func testAutoWidth() {
+        column = .make(width: "auto")
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.columnWidth, .auto)
+        XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.auto.huggingPriority)
+        XCTAssertEqual(columnView.contentCompressionResistancePriority(for: .horizontal), .defaultHigh)
+    }
+    
+    func testStretchWidth() {
+        column = .make(width: "stretch")
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.columnWidth, .stretch)
+        XCTAssertEqual(columnView.contentHuggingPriority(for: .horizontal), ColumnWidth.stretch.huggingPriority)
+        XCTAssertEqual(columnView.contentCompressionResistancePriority(for: .horizontal), .defaultLow)
+    }
+    
+    func testWeightedWidth() {
+        column = .make(width: "20")
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.columnWidth, .weighted(20))
+    }
+    
+    func testConstantWidth() {
+        column = .make(width: "0", pixelWidth: 200)
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.columnWidth, .fixed(200))
+        XCTAssertEqual(columnView.fittingSize.width, 200)
+    }
+    
+    func testMinHeight() {
+        column = .make(minHeight: 200)
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.fittingSize.height, 200)
+    }
+    
+    func testVerticalContentAlignment() {
+        var columnView = renderColumnView()
+        XCTAssertEqual(columnView.arrangedSubviews.count, 0)
+        
+        column = .make(verticalContentAlignment: .center)
+        columnView = renderColumnView()
+        XCTAssertEqual(columnView.arrangedSubviews.count, 2)
+        
+        column = .make(verticalContentAlignment: .bottom)
+        columnView = renderColumnView()
+        XCTAssertEqual(columnView.arrangedSubviews.count, 1)
+    }
+    
+    func testRendersItems() {
+        column = .make(items: [FakeTextBlock.make(), FakeInputNumber.make()])
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.arrangedSubviews.count, 2)
+    }
+    
+    private func renderColumnView() -> ACRColumnView {
+        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: NSView(), parentView: NSView(), inputs: [])
+        
+        XCTAssertTrue(view is ACRContentStackView)
+        guard let columnView = view as? ACRColumnView else { fatalError() }
+        return columnView
+    }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -1,0 +1,53 @@
+@testable import AdaptiveCards
+import AdaptiveCards_bridge
+import XCTest
+
+class ColumnSetRendererTests: XCTestCase {
+    private var hostConfig: FakeHostConfig!
+    private var columnSet: FakeColumnSet!
+    private var columnSetRenderer: ColumnSetRenderer!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        hostConfig = .make()
+        columnSet = .make()
+        columnSetRenderer = ColumnSetRenderer()
+    }
+    
+    func testAllStretchColumns() {
+        let columns: [FakeColumn] = [.make(width: "stretch"), .make(width: "stretch"), .make(width: "stretch")]
+        columnSet = .make(columns: columns)
+        
+        let columnSetView = renderColumnSetView()
+        XCTAssertEqual(columnSetView.distribution, .fillEqually)
+    }
+    
+    func testAllAutoColumns() {
+        let columns: [FakeColumn] = [.make(width: "auto"), .make(width: "auto"), .make(width: "auto")]
+        columnSet = .make(columns: columns)
+        
+        let columnSetView = renderColumnSetView()
+        XCTAssertEqual(columnSetView.distribution, .gravityAreas)
+    }
+    
+    func testMixedWidthColumns() {
+        let columns: [FakeColumn] = [.make(width: "auto"), .make(width: "stretch"), .make(width: "2")]
+        columnSet = .make(columns: columns)
+        
+        let columnSetView = renderColumnSetView()
+        XCTAssertEqual(columnSetView.distribution, .fill)
+    }
+    
+    func testDefaultOrientation() {
+        let columnStackView = renderColumnSetView()
+        XCTAssertEqual(columnStackView.orientation, .horizontal)
+    }
+    
+    private func renderColumnSetView() -> ACRContentStackView {
+        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: NSView(), parentView: NSView(), inputs: [])
+        
+        XCTAssertTrue(view is ACRContentStackView)
+        guard let columnSetView = view as? ACRContentStackView else { fatalError() }
+        return columnSetView
+    }
+}


### PR DESCRIPTION
## Description
- Added spacing, separator, minHeight, style properties to ColumnSet element
- Fixed FactSet alignment
- Refactored code

## Sample Card
<img width="351" alt="Screenshot 2021-03-09 at 9 10 30 PM" src="https://user-images.githubusercontent.com/75681162/110497040-1cf7c780-811c-11eb-96c0-314ee2fcc746.png">
<img width="351" alt="Screenshot 2021-03-09 at 9 10 10 PM" src="https://user-images.githubusercontent.com/75681162/110497072-22eda880-811c-11eb-9e96-6daefff5121d.png">

