### PR TITLE
Text Elements Monospace Font

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -216,7 +216,6 @@ namespace RendererQml
 	{
 		//TODO:Parse markdown in the text
 
-		//TODO: To get the Qml equivalant of monospace fontType and add it to config
 		std::string fontFamily = context->GetConfig()->GetFontFamily(textBlock->GetFontType());
 		int fontSize = context->GetConfig()->GetFontSize(textBlock->GetFontType(), textBlock->GetTextSize());
 
@@ -230,17 +229,12 @@ namespace RendererQml
 
 		uiTextBlock->Property("horizontalAlignment", Utils::GetHorizontalAlignment(horizontalAlignment));
 
-		//TODO: Need to fix the color calculation
 		std::string color = context->GetColor(textBlock->GetTextColor(), textBlock->GetIsSubtle(), false);
 
 		uiTextBlock->Property("color", color);
 
-		//Value based on what is mentioned in the html renderer
-		uiTextBlock->Property("lineHeight", "1.33");
-
 		uiTextBlock->Property("font.pixelSize", std::to_string(fontSize));
 
-		//TODO: lighter weight showing same behaviour as default
 		uiTextBlock->Property("font.weight", Utils::GetWeight(textBlock->GetTextWeight()));
 
 		if (!textBlock->GetId().empty())
@@ -483,21 +477,13 @@ namespace RendererQml
 		const int fontSize = context->GetConfig()->GetFontSize(textRun->GetFontType(), textRun->GetTextSize());
 		const int weight = context->GetConfig()->GetFontWeight(textRun->GetFontType(), textRun->GetTextWeight());
 
-		//Value based on what is mentioned in the html renderer
-		const auto lineHeight = fontSize * 1.33;
-
 		std::string uiTextRun = "<span style='";
 		std::string textType = textRun->GetInlineTypeString();
 
-		//TODO: Add font to hostconfig
 		uiTextRun.append("font-family:" + std::string("\\\"") + fontFamily + std::string("\\\"") + ";");
 
-		//TODO: Need to fix the color calculation
 		std::string color = context->GetColor(textRun->GetTextColor(), textRun->GetIsSubtle(), false, false);
 		uiTextRun.append("color:" + color + ";");
-
-		std::string lineheight = Formatter() << std::fixed << std::setprecision(2) << lineHeight << "px";
-		uiTextRun.append("line-height:" + lineheight + ";");
 
 		uiTextRun.append("font-size:" + std::to_string(fontSize) + "px" + ";");
 

--- a/source/qml/Samples/QmlVisualizer/adaptivecard_dark_config.h
+++ b/source/qml/Samples/QmlVisualizer/adaptivecard_dark_config.h
@@ -27,7 +27,7 @@ namespace DarkConfig
             }
         },
         "monospace":{
-            "fontFamily":"'Courier New', Courier, monospace",
+            "fontFamily":"Courier New, Courier, monospace",
             "fontSizes":{
                 "small":12,
                 "default":14,

--- a/source/qml/Samples/QmlVisualizer/adaptivecard_light_config.h
+++ b/source/qml/Samples/QmlVisualizer/adaptivecard_light_config.h
@@ -27,7 +27,7 @@ namespace LightConfig
             }
         },
         "monospace":{
-            "fontFamily":"'Courier New', Courier, monospace",
+            "fontFamily":"Courier New, Courier, monospace",
             "fontSizes":{
                 "small":12,
                 "default":14,


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Removed line height for textBlock and textRun
Fixed monospace font
## Sample Card
TextBlock Light:
![image](https://user-images.githubusercontent.com/78541663/111456353-e6820400-873c-11eb-81e6-7aa2053e75d1.png)

TextBlock Dark:
![image](https://user-images.githubusercontent.com/78541663/111456434-00234b80-873d-11eb-92c8-f286f41dae06.png)

RichTextBlock Light:
![image](https://user-images.githubusercontent.com/78541663/111456649-437dba00-873d-11eb-9aeb-21b03a976854.png)

RichTextBlock Dark:
![image](https://user-images.githubusercontent.com/78541663/111456741-5d1f0180-873d-11eb-82eb-af3d6524921b.png)

With Line Height (Leads to extra space) :
![image](https://user-images.githubusercontent.com/78541663/111456905-8c357300-873d-11eb-8ab9-04d73382de7e.png)

Without Line Height:
![image](https://user-images.githubusercontent.com/78541663/111456946-96f00800-873d-11eb-8f71-d5c6e6c5fdec.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
