### PR TITLE
RichTextBlock Bug

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -612,32 +612,35 @@ namespace RendererQml
 		std::string uiTextRun = "<span style='";
 		std::string textType = textRun->GetInlineTypeString();
 
-		uiTextRun.append("font-family:" + std::string("\\\"") + fontFamily + std::string("\\\"") + ";");
+		uiTextRun.append(Formatter() << "font-family:" << std::string("\\\"") << fontFamily << std::string("\\\"") << ";");
 
 		std::string color = context->GetColor(textRun->GetTextColor(), textRun->GetIsSubtle(), false, false);
-		uiTextRun.append("color:" + color + ";");
+		uiTextRun.append(Formatter() << "color:" << color << ";");
 
-		uiTextRun.append("font-size:" + std::to_string(fontSize) + "px" + ";");
+		uiTextRun.append(Formatter() << "font-size:" << std::to_string(fontSize) << "px" << ";");
 
-		uiTextRun.append("font-weight:" + std::to_string(weight) + ";");
+		uiTextRun.append(Formatter() << "font-weight:" << std::to_string(weight) << ";");
 
 		if (textRun->GetHighlight())
 		{
-			uiTextRun.append("background-color:" + context->GetColor(textRun->GetTextColor(), textRun->GetIsSubtle(), true, false) + ";");
+			uiTextRun.append(Formatter() << "background-color:" << context->GetColor(textRun->GetTextColor(), textRun->GetIsSubtle(), true, false) << ";");
 		}
 
 		if (textRun->GetItalic())
 		{
-			uiTextRun.append("font-style:" + std::string("italic") + ";");
+			uiTextRun.append(Formatter() << "font-style:" << std::string("italic") << ";");
 		}
 
 		if (textRun->GetStrikethrough())
 		{
-			uiTextRun.append("text-decoration:" + std::string("line-through") + ";");
+			uiTextRun.append(Formatter() << "text-decoration:" << std::string("line-through") << ";");
 		}
 
 		uiTextRun.append("'>");
-		uiTextRun.append(TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang()));
+
+		std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
+		text = Utils::Replace(text, "\n", "<br/>");
+		uiTextRun.append(text);
 		uiTextRun.append("</span>");
 
 		return uiTextRun;


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
On placing "\n" in the text field of a textRun , it was not getting parsed
This is fixed by replacing the "\n" with &lt;br/&gt; html tag  

## Sample Card
Link to JSON: https://adaptivecards.io/samples/FlightDetails.html
![image](https://user-images.githubusercontent.com/78541663/112167774-bc39b600-8c16-11eb-8828-d556b9755187.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
