### PR TITLE
Add markdown for TextBlock

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -274,7 +274,7 @@ namespace RendererQml
 
 	std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::TextBlockRender(std::shared_ptr<AdaptiveCards::TextBlock> textBlock, std::shared_ptr<AdaptiveRenderContext> context)
 	{
-		//TODO:Parse markdown in the text
+		//LIMITATION: Elide and maximumLineCount property do not work for textFormat:Text.MarkdownText
 
 		std::string fontFamily = context->GetConfig()->GetFontFamily(textBlock->GetFontType());
 		int fontSize = context->GetConfig()->GetFontSize(textBlock->GetFontType(), textBlock->GetTextSize());
@@ -284,7 +284,12 @@ namespace RendererQml
 		std::string horizontalAlignment = AdaptiveCards::EnumHelpers::getHorizontalAlignmentEnum().toString(textBlock->GetHorizontalAlignment());
 
 		uiTextBlock->Property("width", "parent.width");
+
+		//Does not work for Markdown text
 		uiTextBlock->Property("elide", "Text.ElideRight");
+
+		uiTextBlock->Property("clip", "true");
+		uiTextBlock->Property("textFormat", "Text.MarkdownText");
 		uiTextBlock->Property("text", "\"" + textBlock->GetText() + "\"");
 
 		uiTextBlock->Property("horizontalAlignment", Utils::GetHorizontalAlignment(horizontalAlignment));
@@ -308,6 +313,7 @@ namespace RendererQml
 			uiTextBlock->Property("visible", "false");
 		}
 
+		//Does not work for Markdown text
 		if (textBlock->GetMaxLines() > 0)
 		{
 			uiTextBlock->Property("maximumLineCount", std::to_string(textBlock->GetMaxLines()));


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description

TextBlock supports markdown

Limitation: 
- Text doesn't get elided when it exceeds the length of the card, instead it gets chopped abruptly
- maxLines property does not work 

## Sample Card
![image](https://user-images.githubusercontent.com/78541663/112297359-ccf03780-8cbb-11eb-88dc-818c7f1fdabd.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
