### PR TITLE
Escape sequences For TextBlock and RichTextBlock

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -386,7 +386,7 @@ namespace RendererQml
 		uiTextBlock->Property("textFormat", "Text.MarkdownText");
 
 		std::string text = TextUtils::ApplyTextFunctions(textBlock->GetText(), context->GetLang());
-		text = Utils::Replace(text, "\"", "\\\"");
+		Utils::HandleEscapeSequences(text, true);
 		uiTextBlock->Property("text", Formatter() << "\"" << text << "\"");
 
 		uiTextBlock->Property("horizontalAlignment", Utils::GetHorizontalAlignment(horizontalAlignment));

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -823,8 +823,8 @@ namespace RendererQml
             uiTextRun.append("<a href='" + selectaction + "'>");
             std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
             text = Utils::HandleEscapeSequences(text);
-			uiTextRun.append(text);
-			uiTextRun.append("</a>");
+            uiTextRun.append(text);
+            uiTextRun.append("</a>");
         }
         else
         {

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -386,7 +386,7 @@ namespace RendererQml
 		uiTextBlock->Property("textFormat", "Text.MarkdownText");
 
 		std::string text = TextUtils::ApplyTextFunctions(textBlock->GetText(), context->GetLang());
-		Utils::HandleEscapeSequences(text);
+		text = Utils::HandleEscapeSequences(text);
 		uiTextBlock->Property("text", Formatter() << "\"" << text << "\"");
 
 		uiTextBlock->Property("horizontalAlignment", Utils::GetHorizontalAlignment(horizontalAlignment));
@@ -822,14 +822,14 @@ namespace RendererQml
         {
             uiTextRun.append("<a href='" + selectaction + "'>");
             std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
-            Utils::HandleEscapeSequences(text);
+            text = Utils::HandleEscapeSequences(text);
 			uiTextRun.append(text);
-            uiTextRun.append("</a>");
+			uiTextRun.append("</a>");
         }
         else
         {
             std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
-            Utils::HandleEscapeSequences(text);
+            text = Utils::HandleEscapeSequences(text);
             uiTextRun.append(text);
         }
 		uiTextRun.append("</span>");

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -386,7 +386,7 @@ namespace RendererQml
 		uiTextBlock->Property("textFormat", "Text.MarkdownText");
 
 		std::string text = TextUtils::ApplyTextFunctions(textBlock->GetText(), context->GetLang());
-		Utils::HandleEscapeSequences(text, true);
+		Utils::HandleEscapeSequences(text);
 		uiTextBlock->Property("text", Formatter() << "\"" << text << "\"");
 
 		uiTextBlock->Property("horizontalAlignment", Utils::GetHorizontalAlignment(horizontalAlignment));
@@ -762,14 +762,14 @@ namespace RendererQml
         {
             uiTextRun.append("<a href='" + selectaction + "'>");
             std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
-            text = Utils::Replace(text, "\n", "<br/>");
-            uiTextRun.append(text);
+            Utils::HandleEscapeSequences(text);
+			uiTextRun.append(text);
             uiTextRun.append("</a>");
         }
         else
         {
             std::string text = TextUtils::ApplyTextFunctions(textRun->GetText(), context->GetLang());
-            text = Utils::Replace(text, "\n", "<br/>");
+            Utils::HandleEscapeSequences(text);
             uiTextRun.append(text);
         }
 		uiTextRun.append("</span>");

--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -452,14 +452,13 @@ namespace RendererQml
 		return splitElements;
 	}
 
-	void Utils::HandleEscapeSequences(std::string& text, bool isTextBlock)
+	void Utils::HandleEscapeSequences(std::string& text)
 	{
-		if (isTextBlock == true)
-		{
-			Replace(text, "\n", "\\\\\n");
-			Replace(text, "\r", "\\\\\r");
-			Replace(text, "\"", "\\\"");
-
-		}
+		text = Replace(text, "\n", "<br />");
+		text = Replace(text, "\r", "<br />");
+		//Handles tab space in RichText, works for MarkdownText as well
+		text = Replace(text, "\t", "<span style='white-space:pre'>\t</span>");
+		text = Replace(text, "\"", "&quot;");
+		text = Replace(text, "\\", "&#92;");
 	}
 }

--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -452,4 +452,14 @@ namespace RendererQml
 		return splitElements;
 	}
 
+	void Utils::HandleEscapeSequences(std::string& text, bool isTextBlock)
+	{
+		if (isTextBlock == true)
+		{
+			Replace(text, "\n", "\\\\\n");
+			Replace(text, "\r", "\\\\\r");
+			Replace(text, "\"", "\\\"");
+
+		}
+	}
 }

--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -452,7 +452,7 @@ namespace RendererQml
 		return splitElements;
 	}
 
-	void Utils::HandleEscapeSequences(std::string& text)
+	std::string Utils::HandleEscapeSequences(std::string& text)
 	{
 		text = Replace(text, "\n", "<br />");
 		text = Replace(text, "\r", "<br />");
@@ -460,5 +460,6 @@ namespace RendererQml
 		text = Replace(text, "\t", "<span style='white-space:pre'>\t</span>");
 		text = Replace(text, "\"", "&quot;");
 		text = Replace(text, "\\", "&#92;");
+		return text;
 	}
 }

--- a/source/qml/Library/RendererQml/Utils.h
+++ b/source/qml/Library/RendererQml/Utils.h
@@ -110,7 +110,7 @@ namespace RendererQml
 		static RendererQml::DateFormat GetSystemDateFormat();
 
 		static std::vector<std::string> splitString(const std::string& string, char delimiter);
-		static void HandleEscapeSequences(std::string& text, bool isTextBlock);
+		static void HandleEscapeSequences(std::string& text);
 
     private:
         Utils() {}

--- a/source/qml/Library/RendererQml/Utils.h
+++ b/source/qml/Library/RendererQml/Utils.h
@@ -110,7 +110,7 @@ namespace RendererQml
 		static RendererQml::DateFormat GetSystemDateFormat();
 
 		static std::vector<std::string> splitString(const std::string& string, char delimiter);
-		static void HandleEscapeSequences(std::string& text);
+		static std::string HandleEscapeSequences(std::string& text);
 
     private:
         Utils() {}

--- a/source/qml/Library/RendererQml/Utils.h
+++ b/source/qml/Library/RendererQml/Utils.h
@@ -110,6 +110,7 @@ namespace RendererQml
 		static RendererQml::DateFormat GetSystemDateFormat();
 
 		static std::vector<std::string> splitString(const std::string& string, char delimiter);
+		static void HandleEscapeSequences(std::string& text, bool isTextBlock);
 
     private:
         Utils() {}


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Handles the following escape sequences for TextBlock and RichTextBlock
- \n
- \r
- \t
- \\\
- \\"

## Sample Card
![image](https://user-images.githubusercontent.com/78541663/112949683-1d9ddf80-9157-11eb-9b66-ffe0dc3f79d3.png)

Child Card
![image](https://user-images.githubusercontent.com/78541663/112949721-27bfde00-9157-11eb-9f03-8b309eef8221.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
