### PR TITLE
[MacOS] Added Horizontal Alignment in ActionSet

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.xib
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,7 +19,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="1044" height="412"/>
+            <rect key="frame" x="0.0" y="0.0" width="1100" height="412"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <scrollView misplaced="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n44-FB-6mh">
@@ -102,17 +102,17 @@
                     </tableHeaderView>
                 </scrollView>
                 <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m2h-No-qKR">
-                    <rect key="frame" x="694" y="61" width="350" height="351"/>
+                    <rect key="frame" x="750" y="61" width="350" height="351"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="AR6-HK-mCL">
-                        <rect key="frame" x="0.0" y="0.0" width="350" height="351"/>
+                        <rect key="frame" x="0.0" y="0.0" width="335" height="351"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsUndo="YES" id="Ww0-OY-Znl">
-                                <rect key="frame" x="0.0" y="0.0" width="350" height="351"/>
+                                <rect key="frame" x="0.0" y="0.0" width="335" height="351"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                <size key="minSize" width="350" height="351"/>
+                                <size key="minSize" width="335" height="351"/>
                                 <size key="maxSize" width="350" height="10000000"/>
                                 <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                             </textView>
@@ -126,12 +126,12 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="CYT-4i-Rnq">
-                        <rect key="frame" x="334" y="0.0" width="16" height="351"/>
+                        <rect key="frame" x="335" y="0.0" width="15" height="351"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O4M-uk-PGq">
-                    <rect key="frame" x="816" y="3" width="155" height="27"/>
+                    <rect key="frame" x="872" y="3" width="155" height="27"/>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Select Host Config" bezelStyle="round" completes="NO" usesDataSource="YES" numberOfVisibleItems="5" id="xyg-WJ-FcE">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -139,7 +139,7 @@
                     </comboBoxCell>
                 </comboBox>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DZe-UF-Cz8">
-                    <rect key="frame" x="846" y="25" width="84" height="32"/>
+                    <rect key="frame" x="902" y="25" width="84" height="32"/>
                     <buttonCell key="cell" type="push" title="Render" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4FA-yZ-Lh4">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -149,17 +149,17 @@
                     </connections>
                 </button>
                 <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a5E-cz-man">
-                    <rect key="frame" x="344" y="7" width="335" height="405"/>
+                    <rect key="frame" x="344" y="7" width="391" height="405"/>
                     <clipView key="contentView" id="zbW-Jb-gxa">
-                        <rect key="frame" x="1" y="1" width="333" height="403"/>
+                        <rect key="frame" x="1" y="1" width="374" height="388"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view id="MdU-rn-yDx">
-                                <rect key="frame" x="0.0" y="0.0" width="333" height="1000"/>
+                                <rect key="frame" x="0.0" y="0.0" width="374" height="985"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wOe-bU-DLU">
-                                        <rect key="frame" x="-8" y="500" width="350" height="0.0"/>
+                                        <rect key="frame" x="-16" y="493" width="350" height="0.0"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="350" id="kJn-4U-cPM"/>
                                         </constraints>
@@ -173,11 +173,11 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="pL3-LP-bvj">
-                        <rect key="frame" x="1" y="388" width="333" height="16"/>
+                        <rect key="frame" x="1" y="389" width="374" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="l6W-JQ-Gkt">
-                        <rect key="frame" x="318" y="1" width="16" height="403"/>
+                        <rect key="frame" x="375" y="1" width="15" height="388"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSActionSet.h
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSActionSet.h
@@ -17,9 +17,10 @@ using namespace AdaptiveCards;
 
 #import "ACSBaseCardElement.h"
 #import "ACSBaseActionElement.h"
+#import "ACSHorizontalAlignment.h"
   
 
-
+enum ACSHorizontalAlignment: NSUInteger;
 
 
 @interface ACSActionSet : ACSBaseCardElement
@@ -30,6 +31,8 @@ using namespace AdaptiveCards;
 
 - (NSArray<ACSBaseActionElement *> * _Nonnull)getActions;
 
+- (ACSHorizontalAlignment)getHorizontalAlignment;
+- (void)setHorizontalAlignment:(enum ACSHorizontalAlignment)value;
 
 
 @end

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSActionSet.mm
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSActionSet.mm
@@ -10,6 +10,7 @@
 
 #import "ACSActionSet.h"
 #import "../../../../../shared/cpp/ObjectModel/ActionSet.h"
+#import "ACSHorizontalAlignmentConvertor.h"
 
 
 @implementation  ACSActionSet {
@@ -36,6 +37,22 @@
     }
     return objList;
 
+
+}
+
+- (ACSHorizontalAlignment)getHorizontalAlignment
+{
+
+    auto getHorizontalAlignmentCpp = mCppObj->GetHorizontalAlignment();
+    return [ACSHorizontalAlignmentConvertor convertCpp:getHorizontalAlignmentCpp];
+
+}
+
+- (void)setHorizontalAlignment:(enum ACSHorizontalAlignment)value
+{
+    auto valueCpp = [ACSHorizontalAlignmentConvertor convertObj:value];
+
+    mCppObj->SetHorizontalAlignment(valueCpp);
 
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
@@ -9,19 +9,22 @@ class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
             logError("Element is not of type ACSActionSet")
             return NSView()
         }
-        return renderView(actions: actionSet.getActions(), with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
+        return renderView(actions: actionSet.getActions(), aligned: actionSet.getHorizontalAlignment(), with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
     }
     
     func renderActionButtons(actions: [ACSBaseActionElement], with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
-        return renderView(actions: actions, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
+        // This renders Action in AdaptiveCards, as it has no
+        // horizontal alignment property, hardcode it to .left
+        return renderView(actions: actions, aligned: .left, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
     }
     
-    private func renderView(actions: [ACSBaseActionElement], with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    private func renderView(actions: [ACSBaseActionElement], aligned alignment: ACSHorizontalAlignment, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
         let actionSetView = ACRActionSetView()
         actionSetView.translatesAutoresizingMaskIntoConstraints = false
         let adaptiveActionHostConfig = hostConfig.getActions()
         
         if let orientation = adaptiveActionHostConfig?.actionsOrientation, orientation == .horizontal {
+            actionSetView.alignment = alignment == .center ? .centerY: (alignment == .right ? .trailing: .leading)
             actionSetView.orientation = .horizontal
         } else {
             actionSetView.orientation = .vertical

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRActionSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRActionSetView.swift
@@ -10,6 +10,7 @@ class ACRActionSetView: NSView {
     
     private var frameWidth: CGFloat = 0
     private var maxFrameWidth: CGFloat = 0
+    private var renderAction: Bool = true
     
     public var totalWidth: CGFloat = 0
     public var actions: [NSView] = []
@@ -30,6 +31,10 @@ class ACRActionSetView: NSView {
         frameWidth = frame.width
         if orientation == .horizontal, totalWidth > frameWidth, totalWidth > maxFrameWidth, frameWidth != 0 {
             maxFrameWidth = frameWidth
+            customLayout()
+        }
+        if orientation == .horizontal, frameWidth != 0, renderAction {
+            renderAction = false
             customLayout()
         }
     }
@@ -67,8 +72,7 @@ class ACRActionSetView: NSView {
         // adding new child stackview to parent stackview and the parent stackview will align child stackview vertically
         stackview.addArrangedSubview(curview)
         stackview.orientation = .vertical
-        stackview.alignment = .leading
-        
+        let gravityArea: NSStackView.Gravity = stackview.alignment == .centerY ? .center: (stackview.alignment == .trailing ? .trailing: .leading)
         totalWidth = 0
         for view in actions {
             accumulatedWidth += view.intrinsicContentSize.width
@@ -80,14 +84,15 @@ class ACRActionSetView: NSView {
                     return view
                 }()
                 curview = newStackView
-                curview.addArrangedSubview(view)
+                curview.orientation = .horizontal
+                curview.addView(view, in: gravityArea)
                 curview.spacing = elementSpacing
                 accumulatedWidth = 0
                 accumulatedWidth += view.intrinsicContentSize.width
                 accumulatedWidth += elementSpacing
-                stackview.addArrangedSubview(newStackView)
+                stackview.addArrangedSubview(curview)
             } else {
-                curview.addArrangedSubview(view)
+                curview.addView(view, in: gravityArea)
                 accumulatedWidth += elementSpacing
             }
         }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeActionSet.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeActionSet.swift
@@ -2,15 +2,25 @@ import AdaptiveCards_bridge
 
 class FakeActionSet: ACSActionSet {
     public var actions: [ACSBaseActionElement] = []
+    public var horizontalAlignment: ACSHorizontalAlignment = .left
 
     open override func getActions() -> [ACSBaseActionElement] {
         return actions
     }
+    
+    open override func getHorizontalAlignment() -> ACSHorizontalAlignment {
+        return horizontalAlignment
+    }
+    
+    open override func setHorizontalAlignment(_ value: ACSHorizontalAlignment) {
+        horizontalAlignment = value
+    }
 }
 extension FakeActionSet {
-    static func make(actions: [ACSBaseActionElement] = []) -> FakeActionSet {
+    static func make(actions: [ACSBaseActionElement] = [], aligned alighnment: ACSHorizontalAlignment = .left) -> FakeActionSet {
         let fakeActionSet = FakeActionSet()
         fakeActionSet.actions = actions
+        fakeActionSet.horizontalAlignment = alighnment
         return fakeActionSet
     }
 }


### PR DESCRIPTION

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Fixed the bridging code and added horizontal alignment property

## Sample Card
Center Aligned
![image](https://user-images.githubusercontent.com/78855675/113117044-b7cf5780-922b-11eb-9d46-480f393aeeda.png)

Left Aligned
![image](https://user-images.githubusercontent.com/78855675/113117110-c6b60a00-922b-11eb-90d7-133b03f6d75f.png)

Right Aligned
![image](https://user-images.githubusercontent.com/78855675/113117167-d2093580-922b-11eb-807b-ab46f92bdbd7.png)



## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
