### PR TITLE
[MacOS] FactSet width fix

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -67,12 +67,15 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
         titleStack.bottomAnchor.constraint(equalTo: mainFactView.bottomAnchor).isActive = true
         // Spacing between title and value in the horizontal Stack
         titleStack.trailingAnchor.constraint(equalTo: valueStack.leadingAnchor, constant: -10).isActive = true
-        // Getting Max width from Host config if it exists
-        let maxAllowedWidth = CGFloat(truncating: factsetConfig?.title.maxWidth ?? 150)
-        if requiredWidth > maxAllowedWidth {
-            titleStack.widthAnchor.constraint(equalToConstant: maxAllowedWidth).isActive = true
+        
+        let constraint = titleStack.widthAnchor.constraint(lessThanOrEqualTo: mainFactView.widthAnchor, multiplier: 0.45)
+        constraint.priority = .defaultHigh
+        constraint.isActive = true
+
+        if let maxWidth = factsetConfig?.title.maxWidth, let maxAllowedWidth = CGFloat(exactly: maxWidth), requiredWidth > maxAllowedWidth {
+            titleStack.widthAnchor.constraint(lessThanOrEqualToConstant: maxAllowedWidth).isActive = true
         } else {
-            titleStack.widthAnchor.constraint(equalToConstant: (requiredWidth + 1)).isActive = true
+            titleStack.widthAnchor.constraint(lessThanOrEqualToConstant: requiredWidth + 2).isActive = true
         }
 
         valueStack.trailingAnchor.constraint(equalTo: mainFactView.trailingAnchor).isActive = true


### PR DESCRIPTION
## Sample Card
<img width="345" alt="image" src="https://user-images.githubusercontent.com/75681162/113160753-6343d080-925b-11eb-9c10-4f5054bf27fd.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/75681162/113160812-70f95600-925b-11eb-8b82-21dbf06eccdc.png">

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
