### PR TITLE
[MacOS]Working horizontal alignment and hover for selectAction Columnset

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ColumnSetAlignment.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ColumnSetAlignment.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "type": "AdaptiveCard",
+    "version": "1.2",
+    "body": [
+        {
+            "type": "ColumnSet",
+            "style": "default",
+            "columns": [
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://adaptivecards.io/content/cats/1.png"
+                        }
+                    ],
+                    "width": "50px"
+                },
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://adaptivecards.io/content/cats/1.png"
+                        }
+                    ],
+                    "width": "50px"
+                },
+                {
+                    "type": "Column",
+                    "items": [
+                        {
+                            "type": "Image",
+                            "url": "https://adaptivecards.io/content/cats/1.png"
+                        }
+                    ],
+                    "width": "50px"
+                }
+            ],
+            "horizontalAlignment": "Right"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSColumnSet.h
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSColumnSet.h
@@ -14,6 +14,7 @@ using namespace AdaptiveCards;
 
 #import "ACSColumn.h"
 #import "ACSParseContext.h"
+#import "ACSHorizontalAlignment.h"
 // #import "ACSRemoteResourceInformation.h"
 // #import "ACSValue.h"
 
@@ -26,7 +27,7 @@ using namespace AdaptiveCards;
 @class ACSParseContext;
 @class ACSRemoteResourceInformation;
 
-
+enum ACSHorizontalAlignment: NSUInteger;
 
 @interface ACSColumnSet : ACSCollectionTypeElement
 
@@ -36,6 +37,9 @@ using namespace AdaptiveCards;
 
 - (NSArray<ACSColumn *> * _Nonnull)getColumns;
 - (void)getResourceInformation:(NSArray<ACSRemoteResourceInformation *>* _Nonnull)resourceInfo;
+
+- (ACSHorizontalAlignment)getHorizontalAlignment;
+- (void)setHorizontalAlignment:(enum ACSHorizontalAlignment)value;
 
 
 

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSColumnSet.mm
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/AutoGenerated/Models/ACSColumnSet.mm
@@ -7,6 +7,7 @@
 #import "ACSColumn.h"
 #import "ACSParseContext.h"
 #import "ACSRemoteResourceInformationConvertor.h"
+#import "ACSHorizontalAlignmentConvertor.h"
 // #import "ACSValue.h"
 
 //cpp includes
@@ -60,6 +61,22 @@
  
     mCppObj->GetResourceInformation(resourceInfoVector);
     
+}
+
+- (ACSHorizontalAlignment)getHorizontalAlignment
+{
+
+    auto getHorizontalAlignmentCpp = mCppObj->GetHorizontalAlignment();
+    return [ACSHorizontalAlignmentConvertor convertCpp:getHorizontalAlignmentCpp];
+
+}
+
+- (void)setHorizontalAlignment:(enum ACSHorizontalAlignment)value
+{
+    auto valueCpp = [ACSHorizontalAlignmentConvertor convertObj:value];
+
+    mCppObj->SetHorizontalAlignment(valueCpp);
+
 }
 
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -12,7 +12,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView)
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
         columnSetView.orientation = .horizontal
-        columnSetView.distribution = .fillEqually
+        let gravityArea: NSStackView.Gravity = columnSet.getHorizontalAlignment() == .center ? .center: (columnSet.getHorizontalAlignment() == .right ? .trailing: .leading)
         
         var numberOfAutoItems = 0
         var numberOfStretchItems = 0
@@ -29,7 +29,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             
             // Check if has extra properties else add column view
             guard index > 0, column.getSpacing() != .none, !column.getSeparator() else {
-                columnSetView.addArrangedSubview(columnView)
+                columnSetView.addView(columnView, in: gravityArea)
                 BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column)
                 continue
             }
@@ -41,7 +41,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             
             wrappingView.addArrangedSubview(columnView)
             columnView.trailingAnchor.constraint(equalTo: wrappingView.trailingAnchor).isActive = true
-            columnSetView.addArrangedSubview(wrappingView)
+            columnSetView.addView(wrappingView, in: gravityArea)
             BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column)
         }
         
@@ -54,6 +54,8 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         if numberOfStretchItems == totalColumns || isSpecialAllStretch {
             columnSetView.distribution = .fillEqually
         } else if numberOfAutoItems == totalColumns {
+            columnSetView.distribution = .gravityAreas
+        } else if numberOfStretchItems == 0 && numberOfWeightedItems == 0 {
             columnSetView.distribution = .gravityAreas
         } else {
             let arrangedSubviews = columnSetView.arrangedSubviews

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -73,7 +73,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         self.style = style
         super.init(frame: .zero)
         initialize()
-        if (parentStyle == nil) || (!style.equals(ACSContainerStyle.none) && !style.equals(parentStyle)) {
+        if style != .none && style != parentStyle {
             if let bgColor = hostConfig.getBackgroundColor(for: style) {
                 layer?.backgroundColor = bgColor.cgColor
             }
@@ -334,31 +334,6 @@ class ACRColumnView: ACRContentStackView {
             
         case .weighted:
             widthConstraint.isActive = false
-        }
-    }
-}
-
-extension ACSContainerStyle {
-    var description: String {
-        switch self {
-        case .accent: return "accent"
-        case .none: return "none"
-        case .default: return "default"
-        case .emphasis: return "emphasis"
-        case .good: return "good"
-        case .attention: return "attention"
-        case .warning: return "warning"
-        @unknown default: return "unknown"
-        }
-    }
-    
-    func equals(_ style: ACSContainerStyle?) -> Bool {
-        guard let style = style else {
-            return false
-        }
-        switch (self, style) {
-        case (.none, .default), (.default, .none): return true
-        default: return style == self
         }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -73,7 +73,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         self.style = style
         super.init(frame: .zero)
         initialize()
-        if style != .none && style != parentStyle {
+        if (parentStyle == nil) || (!style.equals(ACSContainerStyle.none) && !style.equals(parentStyle)) {
             if let bgColor = hostConfig.getBackgroundColor(for: style) {
                 layer?.backgroundColor = bgColor.cgColor
             }
@@ -107,6 +107,10 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     
     func addArrangedSubview(_ subview: NSView) {
         stackView.addArrangedSubview(subview)
+    }
+    
+    func addView(_ view: NSView, in gravity: NSStackView.Gravity) {
+        stackView.addView(view, in: gravity)
     }
     
     func applyPadding(_ padding: CGFloat) {
@@ -217,13 +221,13 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     
     private var previousBackgroundColor: CGColor?
     override func mouseEntered(with event: NSEvent) {
-        guard let columnView = event.trackingArea?.owner as? ACRColumnView, target != nil else { return }
+        guard let columnView = event.trackingArea?.owner as? ACRContentStackView, target != nil else { return }
         previousBackgroundColor = columnView.layer?.backgroundColor
         columnView.layer?.backgroundColor = ColorUtils.hoverColorOnMouseEnter().cgColor
     }
     
     override func mouseExited(with event: NSEvent) {
-        guard let columnView = event.trackingArea?.owner as? ACRColumnView, target != nil else { return }
+        guard let columnView = event.trackingArea?.owner as? ACRContentStackView, target != nil else { return }
         columnView.layer?.backgroundColor = previousBackgroundColor ?? .clear
     }
 }
@@ -330,6 +334,31 @@ class ACRColumnView: ACRContentStackView {
             
         case .weighted:
             widthConstraint.isActive = false
+        }
+    }
+}
+
+extension ACSContainerStyle {
+    var description: String {
+        switch self {
+        case .accent: return "accent"
+        case .none: return "none"
+        case .default: return "default"
+        case .emphasis: return "emphasis"
+        case .good: return "good"
+        case .attention: return "attention"
+        case .warning: return "warning"
+        @unknown default: return "unknown"
+        }
+    }
+    
+    func equals(_ style: ACSContainerStyle?) -> Bool {
+        guard let style = style else {
+            return false
+        }
+        switch (self, style) {
+        case (.none, .default), (.default, .none): return true
+        default: return style == self
         }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
@@ -11,6 +11,8 @@ class FakeColumn: ACSColumn {
     var spacing: ACSSpacing = .default
     var separator: Bool = false
     var id: String? = ""
+    var backgroundImage: ACSBackgroundImage?
+    var selectAction: ACSBaseActionElement?
     
     override func getWidth() -> String? {
         return width
@@ -83,10 +85,18 @@ class FakeColumn: ACSColumn {
     override func getId() -> String? {
         return id
     }
+    
+    override func getBackgroundImage() -> ACSBackgroundImage? {
+        return backgroundImage
+    }
+    
+    override func getSelectAction() -> ACSBaseActionElement? {
+        return selectAction
+    }
 }
 
 extension FakeColumn {
-    static func make(width: String? = "", pixelWidth: NSNumber? = 0, items: [ACSBaseCardElement] = [], style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, minHeight: NSNumber? = nil, bleed: Bool = false, spacing: ACSSpacing = .default, separator: Bool = false) -> FakeColumn {
+    static func make(width: String? = "", pixelWidth: NSNumber? = 0, items: [ACSBaseCardElement] = [], style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, minHeight: NSNumber? = nil, bleed: Bool = false, spacing: ACSSpacing = .default, separator: Bool = false, backgroundImage: ACSBackgroundImage? = nil, selectAction: ACSBaseActionElement? = nil) -> FakeColumn {
         let fakeColumn = FakeColumn()
         fakeColumn.width = width
         fakeColumn.pixelWidth = pixelWidth
@@ -97,6 +107,8 @@ extension FakeColumn {
         fakeColumn.bleed = bleed
         fakeColumn.spacing = spacing
         fakeColumn.separator = separator
+        fakeColumn.backgroundImage = backgroundImage
+        fakeColumn.selectAction = selectAction
         return fakeColumn
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
@@ -4,6 +4,8 @@ class FakeColumnSet: ACSColumnSet {
     var columns: [ACSColumn] = []
     var style: ACSContainerStyle = .default
     var id: String? = ""
+    var selectAction: ACSBaseActionElement?
+    var horizontalAlignment: ACSHorizontalAlignment = .left
     
     override func getColumns() -> [ACSColumn] {
         return columns
@@ -20,13 +22,27 @@ class FakeColumnSet: ACSColumnSet {
     override func getId() -> String? {
         return id
     }
+    
+    override func getSelectAction() -> ACSBaseActionElement? {
+        return selectAction
+    }
+    
+    override func getHorizontalAlignment() -> ACSHorizontalAlignment {
+        return horizontalAlignment
+    }
+    
+    override func setHorizontalAlignment(_ value: ACSHorizontalAlignment) {
+        horizontalAlignment = value
+    }
 }
 
 extension FakeColumnSet {
-    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default) -> FakeColumnSet {
+    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default, selectAction: ACSBaseActionElement? = nil, horizontalAlignment: ACSHorizontalAlignment = .left) -> FakeColumnSet {
         let fakeColumnSet = FakeColumnSet()
         fakeColumnSet.columns = columns
         fakeColumnSet.style = style
+        fakeColumnSet.selectAction = selectAction
+        fakeColumnSet.horizontalAlignment = horizontalAlignment
         return fakeColumnSet
     }
 }


### PR DESCRIPTION
## Related Issue
Added horizontal alignment property in columnset and implemented it, and fixed the bug that makes hover on columnset work when selectAction property exists

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
Right Alignment
![image](https://user-images.githubusercontent.com/78855675/113398641-8df96a80-93bc-11eb-9a02-c4f7e7efc7cf.png)

Center Alignment
![image](https://user-images.githubusercontent.com/78855675/113398677-9e114a00-93bc-11eb-8d68-f2a8f4bddc02.png)

Left Alignment
![image](https://user-images.githubusercontent.com/78855675/113398728-abc6cf80-93bc-11eb-839b-a769d16c5b14.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
