### PR TITLE
[MacOS] resource resolver for iconUrl and imageSet

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
@@ -13,6 +13,10 @@ class ActionOpenURLRenderer: BaseActionElementRendererProtocol {
         let button = ACRButton()
         button.title = openURLAction.getTitle() ?? ""
         
+        if let iconUrl = openURLAction.getIconUrl() {
+            rootView.registerImageHandlingView(button, for: iconUrl)
+        }
+        
         let target = ActionOpenURLTarget(element: openURLAction, delegate: rootView)
         target.configureAction(for: button)
         rootView.addTarget(target)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
@@ -10,12 +10,14 @@ class ActionOpenURLRenderer: BaseActionElementRendererProtocol {
             return NSView()
         }
         
-        let button = ACRButton()
-        button.title = openURLAction.getTitle() ?? ""
-        
-        if let iconUrl = openURLAction.getIconUrl() {
+        let button: ACRButton
+        if let iconUrl = openURLAction.getIconUrl(), !iconUrl.isEmpty {
+            button = ACRButton(wantsIcon: true)
             rootView.registerImageHandlingView(button, for: iconUrl)
+        } else {
+            button = ACRButton(wantsIcon: false)
         }
+        button.title = openURLAction.getTitle() ?? ""
         
         let target = ActionOpenURLTarget(element: openURLAction, delegate: rootView)
         target.configureAction(for: button)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
@@ -18,6 +18,10 @@ class ActionShowCardRenderer: BaseActionElementRendererProtocol {
             return button
         }
         
+        if let iconUrl = showCardAction.getIconUrl() {
+            rootView.registerImageHandlingView(button, for: iconUrl)
+        }
+        
         let target = ActionShowCardTarget(element: showCard, delegate: rootView)
         target.configureAction(for: button)
         rootView.addTarget(target)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
@@ -10,16 +10,18 @@ class ActionShowCardRenderer: BaseActionElementRendererProtocol {
             return NSView()
         }
         
-        let button = ACRButton(wantsChevron: true)
+        let button: ACRButton
+        if let iconUrl = showCardAction.getIconUrl(), !iconUrl.isEmpty {
+            button = ACRButton(wantsChevron: true, wantsIcon: true)
+            rootView.registerImageHandlingView(button, for: iconUrl)
+        } else {
+            button = ACRButton(wantsChevron: true, wantsIcon: false)
+        }
         button.title = showCardAction.getTitle() ?? ""
 
         guard let showCard = showCardAction.getCard() else {
             logError("ShowCard object is nil")
             return button
-        }
-        
-        if let iconUrl = showCardAction.getIconUrl() {
-            rootView.registerImageHandlingView(button, for: iconUrl)
         }
         
         let target = ActionShowCardTarget(element: showCard, delegate: rootView)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
@@ -12,7 +12,11 @@ class ActionSubmitRenderer: BaseActionElementRendererProtocol {
         
         let button = ACRButton()
         button.title = submitAction.getTitle() ?? ""
-        // TODO: Add image and other properties once ACRButton is Fixed
+        
+        if let iconUrl = submitAction.getIconUrl() {
+            rootView.registerImageHandlingView(button, for: iconUrl)
+        }
+        
         let target = ActionSubmitTarget(element: submitAction, delegate: rootView)
         target.configureAction(for: button)
         rootView.addTarget(target)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
@@ -10,12 +10,15 @@ class ActionSubmitRenderer: BaseActionElementRendererProtocol {
             return NSView()
         }
         
-        let button = ACRButton()
-        button.title = submitAction.getTitle() ?? ""
+        let button: ACRButton
         
-        if let iconUrl = submitAction.getIconUrl() {
+        if let iconUrl = submitAction.getIconUrl(), !iconUrl.isEmpty {
+            button = ACRButton(wantsIcon: true)
             rootView.registerImageHandlingView(button, for: iconUrl)
+        } else {
+            button = ACRButton(wantsIcon: false)
         }
+        button.title = submitAction.getTitle() ?? ""
         
         let target = ActionSubmitTarget(element: submitAction, delegate: rootView)
         target.configureAction(for: button)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -16,12 +16,12 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let imageView: NSImageView
+        let imageView: ImageView
         if let dimensions = rootView.getImageDimensions(for: url) {
             let image = NSImage(size: dimensions)
-            imageView = NSImageView(image: image)
+            imageView = ImageView(image: image)
         } else {
-            imageView = NSImageView()
+            imageView = ImageView()
         }
         
         rootView.registerImageHandlingView(imageView, for: url)
@@ -136,7 +136,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
     }
 }
 
-extension NSImageView: ImageHoldingView {
+class ImageView: NSImageView, ImageHoldingView {
     func setImage(_ image: NSImage) {
         if self.image == nil {
             // update constraints only when image view does not contain an image

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
@@ -12,6 +12,12 @@ class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
             return NSView()
         }
         
+        var imageSize: ACSImageSize = imageSet.getImageSize()
+        if imageSize == .auto || imageSize == .stretch || imageSize == .none {
+            imageSize = .medium
+        }
+        collectionViewDataSource.registerImageViews(acsImages: imageSet.getImages(), rootView: rootView, size: imageSize)
+        
         let colView = ACRCollectionView(frame: .zero, imageSet: imageSet, hostConfig: hostConfig)
         colView.translatesAutoresizingMaskIntoConstraints = false
         colView.dataSource = collectionViewDataSource

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
@@ -3,9 +3,7 @@ import AppKit
 
 class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = ImageSetRenderer()
-    // Has to be defined outside the render function
-    let collectionViewDataSource = ACRCollectionViewDatasource()
-    
+ 
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
         guard let imageSet = element as? ACSImageSet else {
             logError("Element is not of type ACSImageSet")
@@ -16,12 +14,14 @@ class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
         if imageSize == .auto || imageSize == .stretch || imageSize == .none {
             imageSize = .medium
         }
-        collectionViewDataSource.registerImageViews(acsImages: imageSet.getImages(), rootView: rootView, size: imageSize)
+        
+        let datasource = ACRCollectionViewDatasource(acsImages: imageSet.getImages(), rootView: rootView, size: imageSize, hostConfig: hostConfig)
+        rootView.addImageSetDatasource(datasource)
         
         let colView = ACRCollectionView(frame: .zero, imageSet: imageSet, hostConfig: hostConfig)
         colView.translatesAutoresizingMaskIntoConstraints = false
-        colView.dataSource = collectionViewDataSource
-        colView.delegate = collectionViewDataSource
+        colView.dataSource = datasource
+        colView.delegate = datasource
         return colView
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
@@ -90,13 +90,17 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         return textView
     }
-    private func addInlineButton(parentview: NSStackView, view: NSView, element: ACSTextInput, style: ACSContainerStyle, with hostConfig: ACSHostConfig, rootview: NSView) {
+    
+    private func addInlineButton(parentview: NSStackView, view: NSView, element: ACSTextInput, style: ACSContainerStyle, with hostConfig: ACSHostConfig, rootview: ACRView) {
         let action = element.getInlineAction()
         let button = ACRButton(style: .inline)
         button.title = action?.getTitle() ?? ""
         button.cornerRadius = 0
         button.isBordered = false
-        
+        if let iconUrl = action?.getIconUrl() {
+            rootview.registerImageHandlingView(button, for: iconUrl)
+        }
+
         let attributedString: NSMutableAttributedString
         attributedString = NSMutableAttributedString(string: button.title)
         if let colorHex = hostConfig.getForegroundColor(style, color: .default, isSubtle: true), let textColor = ColorUtils.color(from: colorHex) {
@@ -112,29 +116,29 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
         button.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.5).isActive = true
         button.attributedTitle = attributedString
         
-        // image icon
-        if let imageIcon = action?.getIconUrl(), !imageIcon.isEmpty {
-            guard let url = URL(string: imageIcon) else { return }
-            DispatchQueue.global().async {
-                guard let data = try? Data(contentsOf: url) else { return }
-                DispatchQueue.main.async {
-                    guard let image = NSImage(data: data) else {
-                        return
-                    }
-                    image.size = .init(width: button.bounds.width, height: button.bounds.height)
-                    button.showsIcon = true
-                    button.title = ""
-                    button.iconImageSize = NSSize(width: 25, height: 25)
-                    button.image = image
-                    // added this to maintain the color of the image
-                    button.iconColor = NSColor(patternImage: image)
-                    button.activeIconColor = button.iconColor
-                    // for icon added left and right contentInsets
-                    button.contentInsets.left = 10
-                    button.contentInsets.right = 10
-                }
-            }
-        }
+//        // image icon
+//        if let imageIcon = action?.getIconUrl(), !imageIcon.isEmpty {
+//            guard let url = URL(string: imageIcon) else { return }
+//            DispatchQueue.global().async {
+//                guard let data = try? Data(contentsOf: url) else { return }
+//                DispatchQueue.main.async {
+//                    guard let image = NSImage(data: data) else {
+//                        return
+//                    }
+//                    image.size = .init(width: button.bounds.width, height: button.bounds.height)
+//                    button.showsIcon = true
+//                    button.title = ""
+//                    button.iconImageSize = NSSize(width: 25, height: 25)
+//                    button.image = image
+//                    // added this to maintain the color of the image
+//                    button.iconColor = NSColor(patternImage: image)
+//                    button.activeIconColor = button.iconColor
+//                    // for icon added left and right contentInsets
+//                    button.contentInsets.left = 10
+//                    button.contentInsets.right = 10
+//                }
+//            }
+//        }
         
         // adding target to the Buttons
         guard let acrView = rootview as? ACRView else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
@@ -93,13 +93,18 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
     
     private func addInlineButton(parentview: NSStackView, view: NSView, element: ACSTextInput, style: ACSContainerStyle, with hostConfig: ACSHostConfig, rootview: ACRView) {
         let action = element.getInlineAction()
-        let button = ACRButton(style: .inline)
-        button.title = action?.getTitle() ?? ""
+        let button: ACRButton
+        if let iconUrl = action?.getIconUrl(), !iconUrl.isEmpty {
+            button = ACRButton(wantsIcon: true, style: .inline)
+            button.title = "" // no button title when iconUrl available
+            rootview.registerImageHandlingView(button, for: iconUrl)
+        } else {
+            button = ACRButton(wantsIcon: false, style: .inline)
+            button.title = action?.getTitle() ?? ""
+        }
+        
         button.cornerRadius = 0
         button.isBordered = false
-        if let iconUrl = action?.getIconUrl() {
-            rootview.registerImageHandlingView(button, for: iconUrl)
-        }
 
         let attributedString: NSMutableAttributedString
         attributedString = NSMutableAttributedString(string: button.title)
@@ -115,30 +120,6 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         button.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.5).isActive = true
         button.attributedTitle = attributedString
-        
-//        // image icon
-//        if let imageIcon = action?.getIconUrl(), !imageIcon.isEmpty {
-//            guard let url = URL(string: imageIcon) else { return }
-//            DispatchQueue.global().async {
-//                guard let data = try? Data(contentsOf: url) else { return }
-//                DispatchQueue.main.async {
-//                    guard let image = NSImage(data: data) else {
-//                        return
-//                    }
-//                    image.size = .init(width: button.bounds.width, height: button.bounds.height)
-//                    button.showsIcon = true
-//                    button.title = ""
-//                    button.iconImageSize = NSSize(width: 25, height: 25)
-//                    button.image = image
-//                    // added this to maintain the color of the image
-//                    button.iconColor = NSColor(patternImage: image)
-//                    button.activeIconColor = button.iconColor
-//                    // for icon added left and right contentInsets
-//                    button.contentInsets.left = 10
-//                    button.contentInsets.right = 10
-//                }
-//            }
-//        }
         
         // adding target to the Buttons
         guard let acrView = rootview as? ACRView else {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
@@ -44,7 +44,7 @@ class ACRButton: FlatButton, ImageHoldingView {
         setupButtonStyle()
     }
     
-    init(frame: NSRect = .zero, wantsChevron: Bool = false, wantsIcon: Bool = true, iconNamed: String = "", iconImageFileType: String = "", iconPosition: NSControl.ImagePosition = .imageLeft, style: ActionStyle = .default) {
+    init(frame: NSRect = .zero, wantsChevron: Bool = false, wantsIcon: Bool = false, iconNamed: String = "", iconImageFileType: String = "", iconPosition: NSControl.ImagePosition = .imageLeft, style: ActionStyle = .default) {
         super.init(frame: frame)
         if wantsChevron {
             showsChevron = wantsChevron
@@ -64,10 +64,7 @@ class ACRButton: FlatButton, ImageHoldingView {
         borderWidth = 1
         onAnimationDuration = 0.0
         offAnimationDuration = 0.0
-        iconColor = NSColor.white
-        activeIconColor = NSColor.white
         momentary = !showsChevron
-        iconColor = .white
         if showsIcon {
             image = BundleUtils.getImage(iconImageName, ofType: iconFileType)
             imagePosition = iconPositioned
@@ -87,7 +84,10 @@ class ACRButton: FlatButton, ImageHoldingView {
     }
     
     func setImage(_ image: NSImage) {
+        iconColor = NSColor(patternImage: image)
+        activeIconColor = iconColor
         self.image = image
+        mouseExited(with: NSEvent()) // this is to force trigger the event for image updation
     }
 
     override open func mouseEntered(with event: NSEvent) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
@@ -8,7 +8,7 @@ enum ActionStyle: String {
     case inline
 }
 
-class ACRButton: FlatButton {
+class ACRButton: FlatButton, ImageHoldingView {
     struct Constants {
         static let blueColorCode = "#007EA8"
         static let darkBlueColorCode = "#0A5E7D"
@@ -44,7 +44,7 @@ class ACRButton: FlatButton {
         setupButtonStyle()
     }
     
-    init(frame: NSRect = .zero, wantsChevron: Bool = false, wantsIcon: Bool = false, iconNamed: String = "", iconImageFileType: String = "", iconPosition: NSControl.ImagePosition = .imageLeft, style: ActionStyle = .default) {
+    init(frame: NSRect = .zero, wantsChevron: Bool = false, wantsIcon: Bool = true, iconNamed: String = "", iconImageFileType: String = "", iconPosition: NSControl.ImagePosition = .imageLeft, style: ActionStyle = .default) {
         super.init(frame: frame)
         if wantsChevron {
             showsChevron = wantsChevron
@@ -84,6 +84,10 @@ class ACRButton: FlatButton {
         if buttonStyle != .inline {
             cornerRadius = bounds.height / 2
         }
+    }
+    
+    func setImage(_ image: NSImage) {
+        self.image = image
     }
 
     override open func mouseEntered(with event: NSEvent) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionView.swift
@@ -27,7 +27,7 @@ class ACRCollectionView: NSCollectionView {
         // TODO: Change minimumLineSpacing to 0 after adding images
         layout.minimumLineSpacing = spacing
         layout.minimumInteritemSpacing = spacing
-        layout.itemSize = ImageUtils.getImageSizeAsCGSize(imageSize: self.imageSize ?? .medium, width: 0, height: 0, with: hostConfig, explicitDimensions: false)
+        layout.itemSize = ImageUtils.getImageSizeAsCGSize(imageSize: self.imageSize, width: 0, height: 0, with: hostConfig, explicitDimensions: false)
         collectionViewLayout = layout
         
         self.backgroundColors = [.clear]
@@ -69,19 +69,23 @@ class ACRCollectionView: NSCollectionView {
 
 // MARK: DataSource for CollectionView
 class ACRCollectionViewDatasource: NSObject, NSCollectionViewDataSource {
-    var imageViews: [ImageSetImageView] = []
-    var images: [ACSImage] = []
-    var imageSize: ACSImageSize = .medium
+    let imageViews: [ImageSetImageView]
+    let images: [ACSImage]
+    let hostConfig: ACSHostConfig
     
-    func registerImageViews(acsImages: [ACSImage], rootView: ACRView, size: ACSImageSize) {
+    init(acsImages: [ACSImage], rootView: ACRView, size: ACSImageSize, hostConfig: ACSHostConfig) {
         self.images = acsImages
-        self.imageSize = size
+        self.hostConfig = hostConfig
+        var imageViews: [ImageSetImageView] = []
         for image in images {
             let imageView = ImageSetImageView()
-            guard let url = image.getUrl() else { continue }
+            imageView.hostConfig = hostConfig
+            imageView.imageSize = size
+            let url = image.getUrl() ?? ""
             rootView.registerImageHandlingView(imageView, for: url)
             imageViews.append(imageView)
         }
+        self.imageViews = imageViews
     }
     
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
@@ -89,7 +93,7 @@ class ACRCollectionViewDatasource: NSObject, NSCollectionViewDataSource {
               let hostConfig = collectionView.hostConfig,
               let item = collectionView.makeItem(withIdentifier: ACRCollectionViewItem.identifier, for: indexPath) as? ACRCollectionViewItem else { return NSCollectionViewItem() }
         
-        item.setupBounds(with: imageViews[indexPath.item], and: imageSize, hostConfig: hostConfig)
+        item.setupBounds(with: imageViews[indexPath.item])
         return item
     }
     
@@ -103,7 +107,21 @@ class ACRCollectionViewDatasource: NSObject, NSCollectionViewDataSource {
 }
 
 class ImageSetImageView: NSImageView, ImageHoldingView {
+    var imageSize: ACSImageSize = .medium
+    var hostConfig: ACSHostConfig?
+    
     func setImage(_ image: NSImage) {
+        guard let config = hostConfig else {
+            self.image = image
+            return
+        }
+        
+        let imageRatio = ImageUtils.getAspectRatio(from: image.size)
+        var maxImageSize = ImageUtils.getImageSizeAsCGSize(imageSize: imageSize, width: 0, height: 0, with: config, explicitDimensions: false)
+        if imageRatio.height < 1 {
+            maxImageSize.height *= imageRatio.height
+        }
+        image.size = maxImageSize
         self.image = image
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
@@ -9,9 +9,7 @@ class ACRCollectionViewItem: NSCollectionViewItem {
     }
     
     private let itemView: NSView = {
-        let view = NSView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
+        return NSView()
     }()
     
     func setupBounds(with imageView: ImageSetImageView) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
@@ -5,12 +5,8 @@ class ACRCollectionViewItem: NSCollectionViewItem {
     static let identifier = NSUserInterfaceItemIdentifier(rawValue: "ImageSetItem")
     
     override func loadView() {
-        view = itemView
+        view = NSView()
     }
-    
-    private let itemView: NSView = {
-        return NSView()
-    }()
     
     func setupBounds(with imageView: ImageSetImageView) {
         imageView.removeFromSuperview()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
@@ -14,29 +14,9 @@ class ACRCollectionViewItem: NSCollectionViewItem {
         return view
     }()
     
-//    func setupItem(with urlString: String, hostConfig: ACSHostConfig, imageSize: ACSImageSize) {
-//        guard let url = URL(string: urlString) else {
-//            logError("URL is invalid")
-//            return
-//        }
-//        DispatchQueue.global().async {
-//            guard let data = try? Data(contentsOf: url) else { return }
-//            DispatchQueue.main.async {
-//                guard let image = NSImage(data: data) else { return }
-//                // Add
-//                let imageRatio = ImageUtils.getAspectRatio(from: image.size)
-//                var maxImageSize = ImageUtils.getImageSizeAsCGSize(imageSize: imageSize, width: 0, height: 0, with: hostConfig, explicitDimensions: false)
-//                if imageRatio.height < 1 {
-//                    maxImageSize.height *= imageRatio.height
-//                }
-//                image.size = maxImageSize
-//                self.itemImageView.image = image
-//            }
-//        }
-//    }
-    
-    func setupBounds(with imageView: ImageSetImageView, and imageSize: ACSImageSize, hostConfig: ACSHostConfig) {
+    func setupBounds(with imageView: ImageSetImageView) {
+        imageView.removeFromSuperview()
         view.addSubview(imageView)
-        view.invalidateIntrinsicContentSize()
+        imageView.frame = view.bounds
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionViewItem.swift
@@ -2,37 +2,41 @@ import AdaptiveCards_bridge
 import Cocoa
 
 class ACRCollectionViewItem: NSCollectionViewItem {
-    static let identifier = NSUserInterfaceItemIdentifier(rawValue: "MyItem")
+    static let identifier = NSUserInterfaceItemIdentifier(rawValue: "ImageSetItem")
     
     override func loadView() {
-        view = itemImageView
+        view = itemView
     }
     
-    private let itemImageView: NSImageView = {
-        let view = NSImageView()
+    private let itemView: NSView = {
+        let view = NSView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.imageAlignment = .alignCenter
         return view
     }()
     
-    func setupItem(with urlString: String, hostConfig: ACSHostConfig, imageSize: ACSImageSize) {
-        guard let url = URL(string: urlString) else {
-            logError("URL is invalid")
-            return
-        }
-        DispatchQueue.global().async {
-            guard let data = try? Data(contentsOf: url) else { return }
-            DispatchQueue.main.async {
-                guard let image = NSImage(data: data) else { return }
-                // Add
-                let imageRatio = ImageUtils.getAspectRatio(from: image.size)
-                var maxImageSize = ImageUtils.getImageSizeAsCGSize(imageSize: imageSize, width: 0, height: 0, with: hostConfig, explicitDimensions: false)
-                if imageRatio.height < 1 {
-                    maxImageSize.height *= imageRatio.height
-                }
-                image.size = maxImageSize
-                self.itemImageView.image = image
-            }
-        }
+//    func setupItem(with urlString: String, hostConfig: ACSHostConfig, imageSize: ACSImageSize) {
+//        guard let url = URL(string: urlString) else {
+//            logError("URL is invalid")
+//            return
+//        }
+//        DispatchQueue.global().async {
+//            guard let data = try? Data(contentsOf: url) else { return }
+//            DispatchQueue.main.async {
+//                guard let image = NSImage(data: data) else { return }
+//                // Add
+//                let imageRatio = ImageUtils.getAspectRatio(from: image.size)
+//                var maxImageSize = ImageUtils.getImageSizeAsCGSize(imageSize: imageSize, width: 0, height: 0, with: hostConfig, explicitDimensions: false)
+//                if imageRatio.height < 1 {
+//                    maxImageSize.height *= imageRatio.height
+//                }
+//                image.size = maxImageSize
+//                self.itemImageView.image = image
+//            }
+//        }
+//    }
+    
+    func setupBounds(with imageView: ImageSetImageView, and imageSize: ACSImageSize, hostConfig: ACSHostConfig) {
+        view.addSubview(imageView)
+        view.invalidateIntrinsicContentSize()
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -20,6 +20,7 @@ class ACRView: ACRColumnView {
 
     private (set) var targets: [TargetHandler] = []
     private (set) var inputHandlers: [InputHandlingViewProtocol] = []
+    private (set) var imageSetDatasources: [ACRCollectionViewDatasource] = []
     private (set) var showCardsMap: [NSNumber: NSView] = [:]
     private (set) var currentShowCardItems: ShowCardItems?
 	private (set) var imageViewMap: [String: [ImageHoldingView]] = [:]
@@ -60,6 +61,10 @@ class ACRView: ACRColumnView {
     
     func addInputHandler(_ handler: InputHandlingViewProtocol) {
         inputHandlers.append(handler)
+    }
+    
+    func addImageSetDatasource(_ datasource: ACRCollectionViewDatasource) {
+        imageSetDatasources.append(datasource)
     }
     
     func addShowCard(_ cardView: ACRView) {


### PR DESCRIPTION
## Description
Resource Resolver for - 
* iconUrl
* ImageSet
* Input (inline)

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.
![Screenshot 2021-04-05 at  49 42 6PM](https://user-images.githubusercontent.com/69314716/113577939-b1801780-963f-11eb-960a-3a7afe957c6c.png)
![Screenshot 2021-04-05 at  50 09 6PM](https://user-images.githubusercontent.com/69314716/113577981-c197f700-963f-11eb-91e6-243bc5e6da77.png)
![Screenshot 2021-04-05 at  50 50 6PM](https://user-images.githubusercontent.com/69314716/113578052-d8d6e480-963f-11eb-94de-6572737fb922.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
