### PR TITLE
fix std::optional<int> conversion in Formatter.h 

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -678,7 +678,7 @@ namespace RendererQml
 		if (input->GetValue() != std::nullopt)
 		{
 			uiNumberInput->Property("readonly property bool hasDefaultValue", "true");
-			uiNumberInput->Property("readonly property int defaultValue", std::to_string(input->GetValue().value()));
+			uiNumberInput->Property("readonly property int defaultValue", Formatter() << input->GetValue());
 		}
 		else if(input->GetMin() == std::nullopt)
 		{
@@ -708,17 +708,17 @@ namespace RendererQml
 		if (input->GetValue() < input->GetMin())
 		{
 			input->SetValue(input->GetMin());
-			uiNumberInput->Property("readonly property int defaultValue", std::to_string(input->GetMin().value()));
+			uiNumberInput->Property("readonly property int defaultValue", Formatter() << input->GetMin());
 		}
 		if (input->GetValue() > input->GetMax())
 		{
 			input->SetValue(input->GetMax());
-			uiNumberInput->Property("readonly property int defaultValue", std::to_string(input->GetMax().value()));
+			uiNumberInput->Property("readonly property int defaultValue", Formatter() << input->GetMax());
 		}
 
-		uiNumberInput->Property("from", std::to_string(input->GetMin().value()));
-		uiNumberInput->Property("to", std::to_string(input->GetMax().value()));
-		uiNumberInput->Property("value", std::to_string(input->GetValue().value()));
+		uiNumberInput->Property("from", Formatter() << input->GetMin());
+		uiNumberInput->Property("to", Formatter() << input->GetMax());
+		uiNumberInput->Property("value", Formatter() << input->GetValue());
 
 		//TODO: Add stretch property
 

--- a/source/qml/Library/RendererQml/Formatter.h
+++ b/source/qml/Library/RendererQml/Formatter.h
@@ -18,6 +18,12 @@ namespace RendererQml
             return *this;
         }
 
+        Formatter& operator<<(const std::optional<int>& value)
+        {
+            m_stream << value.value_or(-1);
+            return *this;
+        }
+
         std::string Str() const;
 
         operator std::string() const;


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
