### PR TITLE
[macos] minor fix for images with explicit dimensions

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
@@ -32,14 +32,13 @@ class ACRImageProperties: NSObject {
             acsImageSize = ACSImageSize.auto
         }
   
+        // update the content size based on image sizes and pixel dimensions
         contentSize = ImageUtils.getImageSizeAsCGSize(imageSize: acsImageSize,
                                                       width: pixelWidth,
                                                       height: pixelHeight,
                                                       with: config,
                                                       explicitDimensions: hasExplicitDimensions)
-        if image != nil {
-            updateContentSize(size: contentSize)
-        }
+        
         acsHorizontalAlignment = imageElement.getHorizontalAlignment()
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -103,9 +103,12 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
                 return
         }
         
-        let imageProperties = superView.imageProperties
-        imageProperties?.updateContentSize(size: imageSize)
-        let cgSize = imageProperties?.contentSize ?? CGSize.zero
+        guard let imageProperties = superView.imageProperties else {
+            logError("imageProperties is null")
+            return
+        }
+        imageProperties.updateContentSize(size: imageSize)
+        let cgSize = imageProperties.contentSize ?? CGSize.zero
         superView.isImageSet = true
         
         let priority = NSLayoutConstraint.Priority.defaultHigh // TODO Need to revisit this for a more generalised logic
@@ -119,10 +122,12 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         
         guard cgSize.width > 0, cgSize.height > 0 else { return }
         
-        constraints.append(imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: cgSize.width / cgSize.height, constant: 0))
-        constraints.append(imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: cgSize.height / cgSize.width, constant: 0))
-        constraints[2].priority = priority + 2
-        constraints[3].priority = priority + 2
+        if !imageProperties.hasExplicitDimensions {
+            constraints.append(imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: cgSize.width / cgSize.height, constant: 0))
+            constraints.append(imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: cgSize.height / cgSize.width, constant: 0))
+            constraints[2].priority = priority + 2
+            constraints[3].priority = priority + 2
+        }
         
         NSLayoutConstraint.activate(constraints)
                     


### PR DESCRIPTION
## Description
* Fix for images with explicit dimensions (Flight card) 
* Fix for breaking images when resource resolver provides dimensions of the image. 

## Sample Card
<img width="1149" alt="Screenshot 2021-04-07 at  40 05 7PM" src="https://user-images.githubusercontent.com/69314716/113880373-0efb9c00-97d9-11eb-889a-32464e5f57e3.png">
<img width="724" alt="Screenshot 2021-04-07 at  41 28 7PM" src="https://user-images.githubusercontent.com/69314716/113880600-423e2b00-97d9-11eb-841d-3d6bd4106309.png">


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
