### PR TITLE
[MacOS]Padding fix for collection Items

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -10,7 +10,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, paddingCollection: column.getPadding())
+        let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, needsPadding: column.getPadding())
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
         columnView.bleed = column.getBleed()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -10,7 +10,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView)
+        let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, paddingCollection: column.getPadding())
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))
         columnView.bleed = column.getBleed()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -9,7 +9,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             logError("Element is not of type ACSColumnSet")
             return NSView()
         }
-        let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView)
+        let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, paddingCollection: columnSet.getPadding())
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
         columnSetView.orientation = .horizontal
         let gravityArea: NSStackView.Gravity = columnSet.getHorizontalAlignment() == .center ? .center: (columnSet.getHorizontalAlignment() == .right ? .trailing: .leading)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -9,7 +9,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             logError("Element is not of type ACSColumnSet")
             return NSView()
         }
-        let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, paddingCollection: columnSet.getPadding())
+        let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: parentView, needsPadding: columnSet.getPadding())
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
         columnSetView.orientation = .horizontal
         let gravityArea: NSStackView.Gravity = columnSet.getHorizontalAlignment() == .center ? .center: (columnSet.getHorizontalAlignment() == .right ? .trailing: .leading)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -10,7 +10,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let containerView = ACRColumnView(style: container.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: rootView)
+        let containerView = ACRColumnView(style: container.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: rootView, paddingCollection: container.getPadding())
         containerView.translatesAutoresizingMaskIntoConstraints = false
         
         containerView.bleed = container.getBleed()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -10,7 +10,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             return NSView()
         }
         
-        let containerView = ACRColumnView(style: container.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: rootView, paddingCollection: container.getPadding())
+        let containerView = ACRColumnView(style: container.getStyle(), parentStyle: style, hostConfig: hostConfig, superview: rootView, needsPadding: container.getPadding())
         containerView.translatesAutoresizingMaskIntoConstraints = false
         
         containerView.bleed = container.getBleed()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -60,8 +60,8 @@ class ACRColumnView: ACRContentStackView {
         return view
     }()
     
-    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, paddingCollection: Bool) {
-        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview, paddingCollection: paddingCollection)
+    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, needsPadding: Bool) {
+        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview, needsPadding: needsPadding)
         initialize()
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -60,8 +60,8 @@ class ACRColumnView: ACRContentStackView {
         return view
     }()
     
-    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?) {
-        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview)
+    override init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, paddingCollection: Bool) {
+        super.init(style: style, parentStyle: parentStyle, hostConfig: hostConfig, superview: superview, paddingCollection: paddingCollection)
         initialize()
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -11,7 +11,6 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     private var stackViewTrailingConstraint: NSLayoutConstraint?
     private var stackViewTopConstraint: NSLayoutConstraint?
     private var stackViewBottomConstraint: NSLayoutConstraint?
-    private var paddingCollection = true
     
     let style: ACSContainerStyle
     let hostConfig: ACSHostConfig
@@ -56,13 +55,12 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         initialize()
     }
     
-    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, paddingCollection: Bool) {
+    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, needsPadding: Bool) {
         self.hostConfig = hostConfig
         self.style = style
-        self.paddingCollection = paddingCollection
         super.init(frame: .zero)
         initialize()
-        if self.paddingCollection {
+        if needsPadding {
             if let bgColor = hostConfig.getBackgroundColor(for: style) {
                 layer?.backgroundColor = bgColor.cgColor
             }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -11,6 +11,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     private var stackViewTrailingConstraint: NSLayoutConstraint?
     private var stackViewTopConstraint: NSLayoutConstraint?
     private var stackViewBottomConstraint: NSLayoutConstraint?
+    private var paddingCollection = true
     
     let style: ACSContainerStyle
     let hostConfig: ACSHostConfig
@@ -55,12 +56,13 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         initialize()
     }
     
-    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?) {
+    init(style: ACSContainerStyle, parentStyle: ACSContainerStyle?, hostConfig: ACSHostConfig, superview: NSView?, paddingCollection: Bool) {
         self.hostConfig = hostConfig
         self.style = style
+        self.paddingCollection = paddingCollection
         super.init(frame: .zero)
         initialize()
-        if style != .none && style != parentStyle {
+        if self.paddingCollection {
             if let bgColor = hostConfig.getBackgroundColor(for: style) {
                 layer?.backgroundColor = bgColor.cgColor
             }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -35,7 +35,7 @@ class ACRView: ACRColumnView {
     }()
     
     init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
-        super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil)
+        super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil, paddingCollection: true)
     }
     
     required init?(coder: NSCoder) {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -35,7 +35,7 @@ class ACRView: ACRColumnView {
     }()
     
     init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
-        super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil, paddingCollection: true)
+        super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil, needsPadding: true)
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Description
1. Padding fix for all collection type items

## Sample Card
<img width="366" alt="Screenshot 2021-04-08 at 1 21 41 PM" src="https://user-images.githubusercontent.com/78854679/113989513-233da880-986e-11eb-85b9-74c177f871dc.png">
<img width="356" alt="Screenshot 2021-04-08 at 1 21 57 PM" src="https://user-images.githubusercontent.com/78854679/113989521-246ed580-986e-11eb-93af-ba2738d89869.png">
<img width="345" alt="Screenshot 2021-04-08 at 1 22 11 PM" src="https://user-images.githubusercontent.com/78854679/113989526-26389900-986e-11eb-80cd-e80b0202da75.png">
<img width="354" alt="Screenshot 2021-04-08 at 1 27 41 PM" src="https://user-images.githubusercontent.com/78854679/113989571-33558800-986e-11eb-8739-4580465231a3.png">


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
