### PR TITLE
[MacOS]ImageSet Working Inside Columns

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
@@ -11,7 +11,7 @@ class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         
         var imageSize: ACSImageSize = imageSet.getImageSize()
-        if imageSize == .auto || imageSize == .stretch || imageSize == .none {
+        if imageSize == .stretch || imageSize == .none {
             imageSize = .medium
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
@@ -19,7 +19,7 @@ class InputTimeRendererTest: XCTestCase {
         inputTime = .make(value: val)
 
         let inputTimeField = renderTimeInput()
-        XCTAssertEqual(inputTimeField.dateValue, val)
+        XCTAssertEqual(inputTimeField.dateValue, "15:30")
     }
 
     func testRendererSetsPlaceholder() {
@@ -35,7 +35,7 @@ class InputTimeRendererTest: XCTestCase {
         inputTime = .make(min: minVal)
 
         let inputTimeField = renderTimeInput()
-        XCTAssertEqual(inputTimeField.minDateValue, minVal)
+        XCTAssertEqual(inputTimeField.minDateValue, "09:30")
     }
 
     func testRendererForMaxValue() {
@@ -43,7 +43,7 @@ class InputTimeRendererTest: XCTestCase {
         inputTime = .make(max: maxValue)
 
         let inputTimeField = renderTimeInput()
-        XCTAssertEqual(inputTimeField.maxDateValue, maxValue)
+        XCTAssertEqual(inputTimeField.maxDateValue, "16:00")
     }
 
     private func renderTimeInput() -> ACRDateField {


### PR DESCRIPTION
## Description
ImageSet now works inside columns with auto property, max size allowed for images is medium image size of hostConfig

## Sample Card
BHP card
![image](https://user-images.githubusercontent.com/78855675/114029086-cd312b00-9896-11eb-82d1-dc2b9ee02bfc.png)

Agenda Card
![image](https://user-images.githubusercontent.com/78855675/114029166-dfab6480-9896-11eb-8eea-009b34897e0d.png)

Food Order card:
![image](https://user-images.githubusercontent.com/78855675/114029276-f94cac00-9896-11eb-906f-698a45611b66.png)

ImageGallery Card:
![image](https://user-images.githubusercontent.com/78855675/114029331-07023180-9897-11eb-8030-a93e71da58f3.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
