### PR TITLE
[MacOS] Added RenderConfig to maintain flags

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -61,7 +61,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
 
         switch AdaptiveCard.parseHostConfig(from: hostConfigString) {
         case .success(let config):
-            let cardView = AdaptiveCard.render(card: card, with: config, width: 335, actionDelegate: self, resourceResolver: self)
+            let cardView = AdaptiveCard.render(card: card, with: config, width: 335, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme))
             // This changes the appearance of the native components depending on the hostConfig
             if #available(OSX 10.14, *) {
                 cardView.appearance = NSAppearance(named: darkTheme ? .darkAqua : .aqua)

--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -30,9 +30,19 @@ open class AdaptiveCard {
         return .success(hostConfig)
     }
     
-    public static func render(card: ACSAdaptiveCard, with hostConfig: ACSHostConfig, width: CGFloat, actionDelegate: AdaptiveCardActionDelegate?, resourceResolver: AdaptiveCardResourceResolver?) -> NSView {
+    public static func render(card: ACSAdaptiveCard, with hostConfig: ACSHostConfig, width: CGFloat, actionDelegate: AdaptiveCardActionDelegate?, resourceResolver: AdaptiveCardResourceResolver?, config: RenderConfig = .default) -> NSView {
         AdaptiveCardRenderer.shared.actionDelegate = actionDelegate
         AdaptiveCardRenderer.shared.resolverDelegate = resourceResolver
-        return AdaptiveCardRenderer.shared.renderAdaptiveCard(card, with: hostConfig, width: width)
+        return AdaptiveCardRenderer.shared.renderAdaptiveCard(card, with: hostConfig, width: width, config: config)
+    }
+}
+
+public struct RenderConfig {
+    public static let `default` = RenderConfig(isDarkMode: false)
+    
+    let isDarkMode: Bool
+    
+    public init(isDarkMode: Bool) {
+        self.isDarkMode = isDarkMode
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/BaseProtocol.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/BaseProtocol.swift
@@ -4,11 +4,11 @@ import AppKit
 protocol BaseInputHandler { }
 
 protocol BaseCardElementRendererProtocol {
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView
 }
 
 protocol BaseActionElementRendererProtocol {
-    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView
+    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView
 }
 
 protocol TargetHandler: NSObject {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ActionOpenURLRenderer: BaseActionElementRendererProtocol {
     static let shared = ActionOpenURLRenderer()
     
-    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let openURLAction = action as? ACSOpenUrlAction else {
             logError("Element is not of type ACSOpenUrlAction")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ActionShowCardRenderer: BaseActionElementRendererProtocol {
     static let shared = ActionShowCardRenderer()
     
-    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let showCardAction = action as? ACSShowCardAction else {
             logError("Element is not of type ACSShowCardAction")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ActionSubmitRenderer: BaseActionElementRendererProtocol {
     static let shared = ActionSubmitRenderer()
     
-    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let submitAction = action as? ACSSubmitAction else {
             logError("Element is not of type ACSSubmitAction")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
@@ -4,21 +4,21 @@ import AppKit
 class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = ActionSetRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let actionSet = element as? ACSActionSet else {
             logError("Element is not of type ACSActionSet")
             return NSView()
         }
-        return renderView(actions: actionSet.getActions(), aligned: actionSet.getHorizontalAlignment(), with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
+        return renderView(actions: actionSet.getActions(), aligned: actionSet.getHorizontalAlignment(), with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs, config: config)
     }
     
-    func renderActionButtons(actions: [ACSBaseActionElement], with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func renderActionButtons(actions: [ACSBaseActionElement], with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         // This renders Action in AdaptiveCards, as it has no
         // horizontal alignment property, hardcode it to .left
-        return renderView(actions: actions, aligned: .left, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
+        return renderView(actions: actions, aligned: .left, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs, config: config)
     }
     
-    private func renderView(actions: [ACSBaseActionElement], aligned alignment: ACSHorizontalAlignment, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    private func renderView(actions: [ACSBaseActionElement], aligned alignment: ACSHorizontalAlignment, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         let actionSetView = ACRActionSetView()
         actionSetView.translatesAutoresizingMaskIntoConstraints = false
         let adaptiveActionHostConfig = hostConfig.getActions()
@@ -61,7 +61,7 @@ class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
             let action = actions[index]
             let renderer = RendererManager.shared.actionRenderer(for: action.getType())
             
-            let view = renderer.render(action: action, with: hostConfig, style: style, rootView: rootView, parentView: rootView, inputs: [])
+            let view = renderer.render(action: action, with: hostConfig, style: style, rootView: rootView, parentView: rootView, inputs: [], config: config)
             
             actionSetView.addArrangedSubView(view)
             if actionSetView.orientation == .vertical {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ChoiceSetInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ChoiceSetInputRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ChoiceSetInputRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = ChoiceSetInputRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let choiceSetInput = element as? ACSChoiceSetInput else {
             logError("Element is not of type ACSChoiceSetInput")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ColumnRenderer: BaseCardElementRendererProtocol {
     static let shared = ColumnRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let column = element as? ACSColumn else {
             logError("Element is not of type ACSColumn")
             return NSView()
@@ -24,7 +24,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
         
         for (index, item) in column.getItems().enumerated() {
             let renderer = RendererManager.shared.renderer(for: item.getType())
-            let view = renderer.render(element: item, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [])
+            let view = renderer.render(element: item, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [], config: config)
             columnView.configureColumnProperties(for: view)
             let viewWithInheritedProperties = BaseCardElementRenderer.shared.updateView(view: view, element: item, rootView: rootView, style: style, hostConfig: hostConfig, isfirstElement: index == 0)
             columnView.addArrangedSubview(viewWithInheritedProperties)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ColumnSetRenderer: BaseCardElementRendererProtocol {
     static let shared = ColumnSetRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let columnSet = element as? ACSColumnSet else {
             logError("Element is not of type ACSColumnSet")
             return NSView()
@@ -26,7 +26,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             if width == .stretch { numberOfStretchItems += 1 }
             if width == .auto { numberOfAutoItems += 1 }
             
-            let columnView = ColumnRenderer.shared.render(element: column, with: hostConfig, style: columnSet.getStyle(), rootView: rootView, parentView: columnSetView, inputs: [])
+            let columnView = ColumnRenderer.shared.render(element: column, with: hostConfig, style: columnSet.getStyle(), rootView: rootView, parentView: columnSetView, inputs: [], config: config)
             
             // Check if has extra properties else add column view
             columnViews.append(columnView)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ContainerRenderer: BaseCardElementRendererProtocol {
     static let shared = ContainerRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let container = element as? ACSContainer else {
             logError("Element is not of type ACSContainer")
             return NSView()
@@ -28,7 +28,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
         for (index, item) in container.getItems().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: item.getType())
-            let view = renderer.render(element: item, with: hostConfig, style: container.getStyle(), rootView: rootView, parentView: containerView, inputs: [])
+            let view = renderer.render(element: item, with: hostConfig, style: container.getStyle(), rootView: rootView, parentView: containerView, inputs: [], config: config)
             let viewWithInheritedProperties = BaseCardElementRenderer().updateView(view: view, element: item, rootView: rootView, style: container.getStyle(), hostConfig: hostConfig, isfirstElement: isFirstElement)
             containerView.addArrangedSubview(viewWithInheritedProperties)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: item, parentElement: container)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = FactSetRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let factSet = element as? ACSFactSet else {
             logError("Element is not of type ACSFactSet")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -3,9 +3,8 @@ import AppKit
 
 class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = ImageRenderer()
-    let sample = "https://messagecardplayground.azurewebsites.net/assets/TxP_Flight.png"
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let imageElement = element as? ACSImage else {
             logError("Element is not of type ACSImage")
             return NSView()
@@ -108,7 +107,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             return
         }
         imageProperties.updateContentSize(size: imageSize)
-        let cgSize = imageProperties.contentSize ?? CGSize.zero
+        let cgSize = imageProperties.contentSize
         superView.isImageSet = true
         
         let priority = NSLayoutConstraint.Priority.defaultHigh // TODO Need to revisit this for a more generalised logic

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = ImageSetRenderer()
  
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let imageSet = element as? ACSImageSet else {
             logError("Element is not of type ACSImageSet")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputDateRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputDateRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 open class InputDateRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = InputDateRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let dateElement = element as? ACSDateInput else {
             logError("Element is not of type ACSDateInput")
             return NSView()
@@ -12,7 +12,7 @@ open class InputDateRenderer: NSObject, BaseCardElementRendererProtocol {
 
         // setting up basic properties for Input.Date Field
         let inputField: ACRDateField = {
-            let view = ACRDateField(isTimeMode: false)
+            let view = ACRDateField(isTimeMode: false, isDarkMode: config.isDarkMode)
             view.translatesAutoresizingMaskIntoConstraints = false
             view.maxDateValue = dateElement.getMax() ?? ""
             view.minDateValue = dateElement.getMin() ?? ""

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 open class InputNumberRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = InputNumberRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let inputElement = element as? ACSNumberInput else {
             logError("Element is not of type ACSNumberInput")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputTimeRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputTimeRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 open class InputTimeRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = InputTimeRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let timeElement = element as? ACSTimeInput else {
             logError("Element is not of type ACSDateInput")
             return NSView()
@@ -12,7 +12,7 @@ open class InputTimeRenderer: NSObject, BaseCardElementRendererProtocol {
 
         // setting up basic properties for Input.Time Field
         let inputField: ACRDateField = {
-            let view = ACRDateField(isTimeMode: true)
+            let view = ACRDateField(isTimeMode: true, isDarkMode: config.isDarkMode)
             let timeValue = valueByAppendingMissingSeconds(timeElement.getValue() ?? "")
             let timeMin = valueByAppendingMissingSeconds(timeElement.getMin() ?? "")
             let timeMax = valueByAppendingMissingSeconds(timeElement.getMax() ?? "")

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputToggleRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputToggleRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class InputToggleRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = InputToggleRenderer()
      
-     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
          guard let inputToggle = element as? ACSToggleInput else {
              logError("Element is not of type ACSToggleInput")
              return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = RichTextBlockRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let richTextBlock = element as? ACSRichTextBlock else {
             logError("Element is not of type ACSRichTextBlock")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = TextBlockRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let textBlock = element as? ACSTextBlock else {
             logError("Element is not of type ACSTextBlock")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
     static let shared = TextInputRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let inputBlock = element as? ACSTextInput else {
             logError("Element is not of type ACSTextInput")
             return NSView()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/UnknownElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/UnknownElementRenderer.swift
@@ -4,20 +4,22 @@ import AppKit
 class UnknownElementRenderer: BaseCardElementRendererProtocol, BaseActionElementRendererProtocol {
     static let shared = UnknownElementRenderer()
     
-    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         switch  element.getFallbackType() {
         case .content:
             guard let fallbackElement = element.getFallbackContent() as? ACSBaseCardElement else {
                 logError("Fallback Content is not of type ACSBaseCardElement")
                 return NSView()
             }
-            return RendererManager.shared.renderer(for: fallbackElement.getType()).render(element: fallbackElement, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs)
+            return RendererManager.shared.renderer(for: fallbackElement.getType()).render(element: fallbackElement, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs, config: config)
         case .none, .drop:
+            return NSView()
+        @unknown default:
             return NSView()
         }
     }
     
-    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler]) -> NSView {
+    func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         return NSView()
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -28,7 +28,8 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
     }()
 
     private lazy var iconButton: NSButtonWithImageSpacing = {
-        let view = NSButtonWithImageSpacing(image: (isTimeMode ? NSImage(named: "NSTouchBarHistoryTemplate") : BundleUtils.getImage("calendar-month-light", ofType: "png")) ?? NSImage(), target: self, action: #selector(mouseDown(with:)))
+        let resourceName = isDarkMode ? "calendar-month-dark" : "calendar-month-light"
+        let view = NSButtonWithImageSpacing(image: (isTimeMode ? NSImage(named: "NSTouchBarHistoryTemplate") : BundleUtils.getImage(resourceName, ofType: "png")) ?? NSImage(), target: self, action: #selector(mouseDown(with:)))
         view.translatesAutoresizingMaskIntoConstraints = false
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.clear.cgColor
@@ -48,6 +49,8 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
     private let datePickerTextfield = NSDatePicker()
     private var popover = NSPopover()
     let isTimeMode: Bool
+    let isDarkMode: Bool
+    
     var selectedDate: Date? = Date()
     var minDateValue: String?
     var maxDateValue: String?
@@ -87,8 +90,9 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
         return !isHidden && !(superview?.isHidden ?? false)
     }
     
-    init(isTimeMode: Bool) {
+    init(isTimeMode: Bool, isDarkMode: Bool) {
         self.isTimeMode = isTimeMode
+        self.isDarkMode = isDarkMode
         super.init(frame: .zero)
         setupViews()
         setupConstraints()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -17,6 +17,8 @@ class ACRView: ACRColumnView {
     weak var delegate: ACRViewDelegate?
     weak var resolverDelegate: ACRViewResourceResolverDelegate?
     weak var parent: ACRView?
+    
+    let renderConfig: RenderConfig
 
     private (set) var targets: [TargetHandler] = []
     private (set) var inputHandlers: [InputHandlingViewProtocol] = []
@@ -34,11 +36,13 @@ class ACRView: ACRColumnView {
         return view
     }()
     
-    init(style: ACSContainerStyle, hostConfig: ACSHostConfig) {
+    init(style: ACSContainerStyle, hostConfig: ACSHostConfig, renderConfig: RenderConfig) {
+        self.renderConfig = renderConfig
         super.init(style: style, parentStyle: nil, hostConfig: hostConfig, superview: nil, needsPadding: true)
     }
     
     required init?(coder: NSCoder) {
+        renderConfig = .default
         super.init(coder: coder)
     }
     
@@ -99,7 +103,7 @@ extension ACRView: TargetHandlerDelegate {
         }
         
         func manageShowCard(with id: NSNumber) {
-            let cardView = showCardsMap[id] ?? AdaptiveCardRenderer.shared.renderShowCard(showCard, with: hostConfig, parent: self)
+            let cardView = showCardsMap[id] ?? AdaptiveCardRenderer.shared.renderShowCard(showCard, with: hostConfig, parent: self, config: renderConfig)
             showCardsMap[cardId] = cardView
             currentShowCardItems = (cardId, button, cardView)
             cardView.isHidden = false

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumn.swift
@@ -13,6 +13,7 @@ class FakeColumn: ACSColumn {
     var id: String? = ""
     var backgroundImage: ACSBackgroundImage?
     var selectAction: ACSBaseActionElement?
+    var padding: Bool = false
     
     override func getWidth() -> String? {
         return width
@@ -93,10 +94,14 @@ class FakeColumn: ACSColumn {
     override func getId() -> String? {
         return id
     }
+    
+    override func getPadding() -> Bool {
+        return padding
+    }
 }
 
 extension FakeColumn {
-    static func make(width: String? = "", pixelWidth: NSNumber? = 0, items: [ACSBaseCardElement] = [], style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, minHeight: NSNumber? = nil, bleed: Bool = false, spacing: ACSSpacing = .default, separator: Bool = false, backgroundImage: ACSBackgroundImage? = nil, selectAction: ACSBaseActionElement? = nil) -> FakeColumn {
+    static func make(width: String? = "", pixelWidth: NSNumber? = 0, items: [ACSBaseCardElement] = [], style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, minHeight: NSNumber? = nil, bleed: Bool = false, spacing: ACSSpacing = .default, separator: Bool = false, backgroundImage: ACSBackgroundImage? = nil, selectAction: ACSBaseActionElement? = nil, padding: Bool = false) -> FakeColumn {
         let fakeColumn = FakeColumn()
         fakeColumn.width = width
         fakeColumn.pixelWidth = pixelWidth

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeColumnSet.swift
@@ -6,6 +6,7 @@ class FakeColumnSet: ACSColumnSet {
     var id: String? = ""
     var selectAction: ACSBaseActionElement?
     var horizontalAlignment: ACSHorizontalAlignment = .left
+    var padding: Bool = false
     
     override func getColumns() -> [ACSColumn] {
         return columns
@@ -34,15 +35,20 @@ class FakeColumnSet: ACSColumnSet {
     override func setHorizontalAlignment(_ value: ACSHorizontalAlignment) {
         horizontalAlignment = value
     }
+    
+    override func getPadding() -> Bool {
+        return padding
+    }
 }
 
 extension FakeColumnSet {
-    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default, selectAction: ACSBaseActionElement? = nil, horizontalAlignment: ACSHorizontalAlignment = .left) -> FakeColumnSet {
+    static func make(columns: [ACSColumn] = [], style: ACSContainerStyle = .default, selectAction: ACSBaseActionElement? = nil, horizontalAlignment: ACSHorizontalAlignment = .left, padding: Bool = false) -> FakeColumnSet {
        let fakeColumnSet = FakeColumnSet()
         fakeColumnSet.columns = columns
         fakeColumnSet.style = style
         fakeColumnSet.selectAction = selectAction
         fakeColumnSet.horizontalAlignment = horizontalAlignment
+        fakeColumnSet.padding = padding
         return fakeColumnSet
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
@@ -8,6 +8,7 @@ class FakeContainer: ACSContainer {
     public var minHeight: NSNumber?
     public var selectAction: ACSBaseActionElement?
     public var items: [ACSBaseCardElement] = []
+    public var padding: Bool = false
     
     open override func getStyle() -> ACSContainerStyle {
         return style
@@ -60,9 +61,13 @@ class FakeContainer: ACSContainer {
     open override func getItems() -> [ACSBaseCardElement] {
         return items
     }
+    
+    open override func getPadding() -> Bool {
+        return padding
+    }
 }
 extension FakeContainer {
-    static func make(style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, bleed: Bool = false, backgroundImage: ACSBackgroundImage? = nil, minHeight: NSNumber? = 0, selectAction: ACSBaseActionElement? = .none, items: [ACSBaseCardElement] = []) -> FakeContainer {
+    static func make(style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, bleed: Bool = false, backgroundImage: ACSBackgroundImage? = nil, minHeight: NSNumber? = 0, selectAction: ACSBaseActionElement? = .none, items: [ACSBaseCardElement] = [], padding: Bool = false) -> FakeContainer {
         let fakeContainer = FakeContainer()
         fakeContainer.style = style
         fakeContainer.verticalContentAlignment = verticalContentAlignment
@@ -71,6 +76,7 @@ extension FakeContainer {
         fakeContainer.minHeight = minHeight
         fakeContainer.selectAction = selectAction
         fakeContainer.items = items
+        fakeContainer.padding = padding
         return fakeContainer
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/Views/FakeRootView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/Views/FakeRootView.swift
@@ -2,7 +2,7 @@
 
 class FakeRootView: ACRView {
     init() {
-        super.init(style: .default, hostConfig: FakeHostConfig.make())
+        super.init(style: .default, hostConfig: FakeHostConfig.make(), renderConfig: .default)
     }
     
     required init?(coder: NSCoder) {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionOpenURLRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionOpenURLRendererTests.swift
@@ -44,7 +44,7 @@ class ActionOpenURLRendererTests: XCTestCase {
     }
     
     private func renderButton() -> ACRButton {
-        let view = actionOpenURLRenderer.render(action: actionOpenURL, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [])
+        let view = actionOpenURLRenderer.render(action: actionOpenURL, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionOpenURLRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionOpenURLRendererTests.swift
@@ -14,7 +14,7 @@ class ActionOpenURLRendererTests: XCTestCase {
         hostConfig = .make()
         actionOpenURL = .make()
         delegate = FakeACRViewOpenURLDelegate()
-        acrView = ACRView(style: .default, hostConfig: hostConfig)
+        acrView = ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default)
         actionOpenURLRenderer = ActionOpenURLRenderer()
     }
     
@@ -44,7 +44,7 @@ class ActionOpenURLRendererTests: XCTestCase {
     }
     
     private func renderButton() -> ACRButton {
-        let view = actionOpenURLRenderer.render(action: actionOpenURL, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
+        let view = actionOpenURLRenderer.render(action: actionOpenURL, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSetRendererTests.swift
@@ -66,7 +66,7 @@ class ActionSetRendererTests: XCTestCase {
     }
     
     private func renderActionSetView() -> ACRActionSetView {
-        let view = actionSetRenderer.render(element: actionSet, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [], config: config)
+        let view = actionSetRenderer.render(element: actionSet, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRActionSetView)
         guard let actionSetView = view as? ACRActionSetView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSetRendererTests.swift
@@ -66,7 +66,7 @@ class ActionSetRendererTests: XCTestCase {
     }
     
     private func renderActionSetView() -> ACRActionSetView {
-        let view = actionSetRenderer.render(element: actionSet, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [])
+        let view = actionSetRenderer.render(element: actionSet, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRActionSetView)
         guard let actionSetView = view as? ACRActionSetView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionShowCardRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionShowCardRendererTests.swift
@@ -36,7 +36,7 @@ class ActionShowCardRendererTests: XCTestCase {
     }
     
     private func renderButton() -> ACRButton {
-        let view = actionShowCardRenderer.render(action: actionShowCard, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [])
+        let view = actionShowCardRenderer.render(action: actionShowCard, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionShowCardRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionShowCardRendererTests.swift
@@ -12,7 +12,7 @@ class ActionShowCardRendererTests: XCTestCase {
         try super.setUpWithError()
         hostConfig = .make()
         actionShowCard = .make()
-        acrView = ACRView(style: .default, hostConfig: hostConfig)
+        acrView = ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default)
         actionShowCardRenderer = ActionShowCardRenderer()
     }
     
@@ -36,7 +36,7 @@ class ActionShowCardRendererTests: XCTestCase {
     }
     
     private func renderButton() -> ACRButton {
-        let view = actionShowCardRenderer.render(action: actionShowCard, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
+        let view = actionShowCardRenderer.render(action: actionShowCard, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSubmitRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSubmitRendererTests.swift
@@ -96,7 +96,7 @@ class ActionSubmitRendererTests: XCTestCase {
     
     
     private func renderButton() -> ACRButton {
-        let view = actionSubmitRenderer.render(action: actionSubmit, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [])
+        let view = actionSubmitRenderer.render(action: actionSubmit, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSubmitRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionSubmitRendererTests.swift
@@ -13,7 +13,7 @@ class ActionSubmitRendererTests: XCTestCase {
         try super.setUpWithError()
         hostConfig = .make()
         actionSubmit = .make()
-        acrView = ACRView(style: .default, hostConfig: hostConfig)
+        acrView = ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default)
         delegate = FakeACRViewDelegate()
         actionSubmitRenderer = ActionSubmitRenderer()
     }
@@ -96,7 +96,7 @@ class ActionSubmitRendererTests: XCTestCase {
     
     
     private func renderButton() -> ACRButton {
-        let view = actionSubmitRenderer.render(action: actionSubmit, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: config)
+        let view = actionSubmitRenderer.render(action: actionSubmit, with: hostConfig, style: .default, rootView: acrView, parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRButton)
         guard let button = view as? ACRButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionsRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionsRendererTests.swift
@@ -38,7 +38,7 @@ class ActionsRendererTests: XCTestCase {
     }
     
     private func renderActionsView() -> ACRActionSetView {
-        let view = actionSetRenderer.renderActionButtons(actions: actions, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [], config: config)
+        let view = actionSetRenderer.renderActionButtons(actions: actions, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRActionSetView)
         guard let actionSetView = view as? ACRActionSetView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionsRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ActionsRendererTests.swift
@@ -38,7 +38,7 @@ class ActionsRendererTests: XCTestCase {
     }
     
     private func renderActionsView() -> ACRActionSetView {
-        let view = actionSetRenderer.renderActionButtons(actions: actions, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [])
+        let view = actionSetRenderer.renderActionButtons(actions: actions, with: hostConfig, style: .default, rootView: ACRView(style: .default, hostConfig: hostConfig), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRActionSetView)
         guard let actionSetView = view as? ACRActionSetView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
@@ -55,7 +55,7 @@ class ChoiceSetInputRendererTests: XCTestCase {
     }
     
     private func renderChoiceSetView() -> ACRChoiceSetView {
-        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRChoiceSetView)
         guard let choiceSetView = view as? ACRChoiceSetView else { fatalError() }
@@ -63,7 +63,7 @@ class ChoiceSetInputRendererTests: XCTestCase {
     }
     
     private func renderChoiceSetCompactView() -> ACRChoiceSetCompactView {
-        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRChoiceSetCompactView)
         guard let choiceSetCompactView = view as? ACRChoiceSetCompactView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ChoiceSetInputRendererTests.swift
@@ -55,7 +55,7 @@ class ChoiceSetInputRendererTests: XCTestCase {
     }
     
     private func renderChoiceSetView() -> ACRChoiceSetView {
-        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRChoiceSetView)
         guard let choiceSetView = view as? ACRChoiceSetView else { fatalError() }
@@ -63,7 +63,7 @@ class ChoiceSetInputRendererTests: XCTestCase {
     }
     
     private func renderChoiceSetCompactView() -> ACRChoiceSetCompactView {
-        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = choiceSetInputRenderer.render(element: choiceSetInput, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRChoiceSetCompactView)
         guard let choiceSetCompactView = view as? ACRChoiceSetCompactView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -69,7 +69,7 @@ class ColumnRendererTests: XCTestCase {
     }
     
     private func renderColumnView() -> ACRColumnView {
-        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnView = view as? ACRColumnView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -69,7 +69,7 @@ class ColumnRendererTests: XCTestCase {
     }
     
     private func renderColumnView() -> ACRColumnView {
-        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnView = view as? ACRColumnView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -44,7 +44,7 @@ class ColumnSetRendererTests: XCTestCase {
     }
     
     private func renderColumnSetView() -> ACRContentStackView {
-        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnSetView = view as? ACRContentStackView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnSetRendererTests.swift
@@ -44,7 +44,7 @@ class ColumnSetRendererTests: XCTestCase {
     }
     
     private func renderColumnSetView() -> ACRContentStackView {
-        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = columnSetRenderer.render(element: columnSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentStackView)
         guard let columnSetView = view as? ACRContentStackView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -47,7 +47,7 @@ class ContainerRendererTests: XCTestCase {
     }
     
     private func renderContainerView() -> ACRColumnView {
-        let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRColumnView)
         guard let containerView = view as? ACRColumnView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -47,7 +47,7 @@ class ContainerRendererTests: XCTestCase {
     }
     
     private func renderContainerView() -> ACRColumnView {
-        let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRColumnView)
         guard let containerView = view as? ACRColumnView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/FactSetRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/FactSetRendererTest.swift
@@ -141,7 +141,7 @@ class FactSetRendererTest: XCTestCase {
     }
     
     private func renderFactSet() -> NSView {
-        let view = factSetRenderer.render(element: factSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = factSetRenderer.render(element: factSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         return view
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/FactSetRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/FactSetRendererTest.swift
@@ -141,7 +141,7 @@ class FactSetRendererTest: XCTestCase {
     }
     
     private func renderFactSet() -> NSView {
-        let view = factSetRenderer.render(element: factSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = factSetRenderer.render(element: factSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         return view
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
@@ -87,7 +87,7 @@ class ImageRendererTests: XCTestCase {
     }
     
     private func renderImageView() -> ACRContentHoldingView {
-        let view = imageRenderer.render(element: fakeImageView, with: hostConfig, style: .default, rootView: fakeACRView, parentView: fakeACRView, inputs: [])
+        let view = imageRenderer.render(element: fakeImageView, with: hostConfig, style: .default, rootView: fakeACRView, parentView: fakeACRView, inputs: [], config: config)
         
         XCTAssertTrue(view is ACRContentHoldingView)
         guard let contentView = view as? ACRContentHoldingView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
@@ -14,7 +14,7 @@ class ImageRendererTests: XCTestCase {
         hostConfig = .make(imageSizes: ACSImageSizesConfig(smallSize: 30, mediumSize: 60, largeSize: 120))
         fakeImageView = .make()
         imageRenderer = ImageRenderer()
-        fakeACRView = ACRView(style: .default, hostConfig: hostConfig)
+        fakeACRView = ACRView(style: .default, hostConfig: hostConfig, renderConfig: .default)
     }
     
     func testRendererSetsImage() {
@@ -87,7 +87,7 @@ class ImageRendererTests: XCTestCase {
     }
     
     private func renderImageView() -> ACRContentHoldingView {
-        let view = imageRenderer.render(element: fakeImageView, with: hostConfig, style: .default, rootView: fakeACRView, parentView: fakeACRView, inputs: [], config: config)
+        let view = imageRenderer.render(element: fakeImageView, with: hostConfig, style: .default, rootView: fakeACRView, parentView: fakeACRView, inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRContentHoldingView)
         guard let contentView = view as? ACRContentHoldingView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
@@ -47,7 +47,7 @@ class InputDateRendererTest: XCTestCase {
     }
 
     private func renderDateInput() -> ACRDateField {
-        let view = inputDateRenderer.render(element: inputDate, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = inputDateRenderer.render(element: inputDate, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
 
         XCTAssertTrue(view is ACRDateField)
         guard let inputDate = view as? ACRDateField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputDateRendererTests.swift
@@ -47,7 +47,7 @@ class InputDateRendererTest: XCTestCase {
     }
 
     private func renderDateInput() -> ACRDateField {
-        let view = inputDateRenderer.render(element: inputDate, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = inputDateRenderer.render(element: inputDate, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
 
         XCTAssertTrue(view is ACRDateField)
         guard let inputDate = view as? ACRDateField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
@@ -79,7 +79,7 @@ class InputNumberRendererTest: XCTestCase {
     }
        
     private func renderNumberInput() -> ACRNumericTextField {
-        let view = inputNumberRenderer.render(element: inputNumber, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = inputNumberRenderer.render(element: inputNumber, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRNumericTextField)
         guard let inputNumber = view as? ACRNumericTextField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputNumberRendererTest.swift
@@ -79,7 +79,7 @@ class InputNumberRendererTest: XCTestCase {
     }
        
     private func renderNumberInput() -> ACRNumericTextField {
-        let view = inputNumberRenderer.render(element: inputNumber, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = inputNumberRenderer.render(element: inputNumber, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRNumericTextField)
         guard let inputNumber = view as? ACRNumericTextField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
@@ -47,7 +47,7 @@ class InputTimeRendererTest: XCTestCase {
     }
 
     private func renderTimeInput() -> ACRDateField {
-        let view = inputTimeRenderer.render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = inputTimeRenderer.render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
 
         XCTAssertTrue(view is ACRDateField)
         guard let inputTime = view as? ACRDateField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputTimeRendererTests.swift
@@ -47,7 +47,7 @@ class InputTimeRendererTest: XCTestCase {
     }
 
     private func renderTimeInput() -> ACRDateField {
-        let view = inputTimeRenderer.render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = inputTimeRenderer.render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
 
         XCTAssertTrue(view is ACRDateField)
         guard let inputTime = view as? ACRDateField else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
@@ -68,7 +68,7 @@ class InputToggleRendererTests: XCTestCase {
     }
     
     private func renderInputToggleView() -> ACRChoiceButton {
-        let view = inputToggleRenderer.render(element: inputToggle, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = inputToggleRenderer.render(element: inputToggle, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRChoiceButton)
         guard let inputToggleView = view as? ACRChoiceButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/InputToggleRendererTests.swift
@@ -68,7 +68,7 @@ class InputToggleRendererTests: XCTestCase {
     }
     
     private func renderInputToggleView() -> ACRChoiceButton {
-        let view = inputToggleRenderer.render(element: inputToggle, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = inputToggleRenderer.render(element: inputToggle, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRChoiceButton)
         guard let inputToggleView = view as? ACRChoiceButton else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/MultilineInputTextRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/MultilineInputTextRendererTest.swift
@@ -41,7 +41,7 @@ class MultilineInputTextRendererTest: XCTestCase {
     
     
     private func renderTextInput() -> ACRMultilineInputTextView {
-        let view = multilineInputTextRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = multilineInputTextRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRMultilineInputTextView)
         guard let inputText = view as? ACRMultilineInputTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/MultilineInputTextRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/MultilineInputTextRendererTest.swift
@@ -41,7 +41,7 @@ class MultilineInputTextRendererTest: XCTestCase {
     
     
     private func renderTextInput() -> ACRMultilineInputTextView {
-        let view = multilineInputTextRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = multilineInputTextRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRMultilineInputTextView)
         guard let inputText = view as? ACRMultilineInputTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
@@ -82,7 +82,7 @@ class RichTextBlockRendererTests: XCTestCase {
     
 
     private func renderTextView() -> ACRTextView {
-        let view = richTextBlockRenderer.render(element: richTextBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = richTextBlockRenderer.render(element: richTextBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRTextView)
         guard let textView = view as? ACRTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
@@ -82,7 +82,7 @@ class RichTextBlockRendererTests: XCTestCase {
     
 
     private func renderTextView() -> ACRTextView {
-        let view = richTextBlockRenderer.render(element: richTextBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = richTextBlockRenderer.render(element: richTextBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRTextView)
         guard let textView = view as? ACRTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
@@ -77,7 +77,7 @@ class TextBlockRendererTests: XCTestCase {
     }
     
     private func renderTextView() -> ACRTextView {
-        let view = textBlockRenderer.render(element: textBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = textBlockRenderer.render(element: textBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRTextView)
         guard let textView = view as? ACRTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
@@ -77,7 +77,7 @@ class TextBlockRendererTests: XCTestCase {
     }
     
     private func renderTextView() -> ACRTextView {
-        let view = textBlockRenderer.render(element: textBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = textBlockRenderer.render(element: textBlock, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRTextView)
         guard let textView = view as? ACRTextView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
@@ -39,7 +39,7 @@ class TextInputRendererTest: XCTestCase {
     }
     
     private func renderTextInput() -> ACRTextInputView {
-        let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         
         XCTAssertTrue(view is ACRTextInputView)
         guard let inputText = view as? ACRTextInputView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextInputRedererTest.swift
@@ -39,7 +39,7 @@ class TextInputRendererTest: XCTestCase {
     }
     
     private func renderTextInput() -> ACRTextInputView {
-        let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [])
+        let view = textInputRenderer.render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
         
         XCTAssertTrue(view is ACRTextInputView)
         guard let inputText = view as? ACRTextInputView else { fatalError() }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -9,7 +9,7 @@ class ACRViewTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        view = ACRView(style: .default, hostConfig: FakeHostConfig.make())
+        view = ACRView(style: .default, hostConfig: FakeHostConfig.make(), renderConfig: .default)
         fakeResourceResolver = FakeResourceResolver()
         view.resolverDelegate = fakeResourceResolver
         fakeACRViewDelegate = FakeACRViewDelegate()
@@ -78,7 +78,7 @@ class ACRViewTests: XCTestCase {
     
     // Test when ShowCard's Submit Action is Clicked
     func testSubmitActionCountWithAShowCard() {
-        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig())
+        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig(), renderConfig: .default)
         fakeShowCard.delegate = fakeACRViewDelegate
         
         view.addShowCard(fakeShowCard)
@@ -89,8 +89,8 @@ class ACRViewTests: XCTestCase {
     
     // Test when ShowCard's Submit Action is clicked in nested setup
     func testSubmitActionCountWithNestedShowCard() {
-        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig())
-        let fakeShowCard2 = ACRView(style: .default, hostConfig: FakeHostConfig())
+        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig(), renderConfig: .default)
+        let fakeShowCard2 = ACRView(style: .default, hostConfig: FakeHostConfig(), renderConfig: .default)
         
         fakeShowCard.addInputHandler(fakeInputHandlingView())
         fakeShowCard.addInputHandler(fakeInputHandlingView())
@@ -109,8 +109,8 @@ class ACRViewTests: XCTestCase {
     
     // Test when ShowCard's Submit Action is clicked with sibling showcard
     func testSubmitActionCountWithSiblingShowCard() {
-        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig())
-        let fakeShowCard2 = ACRView(style: .default, hostConfig: FakeHostConfig())
+        let fakeShowCard = ACRView(style: .default, hostConfig: FakeHostConfig(), renderConfig: .default)
+        let fakeShowCard2 = ACRView(style: .default, hostConfig: FakeHostConfig(), renderConfig: .default)
         
         fakeShowCard.addInputHandler(fakeInputHandlingView())
         fakeShowCard2.addInputHandler(fakeInputHandlingView())


### PR DESCRIPTION
## Sample Card
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/75681162/114147894-cbb73f80-9936-11eb-98a4-b03c491ace7b.png">
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/75681162/114147926-d5d93e00-9936-11eb-91f2-8f6b22b89c3e.png">

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
