### PR TITLE
[MacOS] fix for extra padding in images in columnset

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
@@ -10,7 +10,7 @@ class ACRImageProperties: NSObject {
     var pixelWidth: CGFloat = 0
     var pixelHeight: CGFloat = 0
     
-    init(element: ACSBaseCardElement, config: ACSHostConfig, image: NSImage?, parentView: NSView) {
+    init(element: ACSBaseCardElement, config: ACSHostConfig, parentView: NSView) {
         super.init()
         guard let imageElement = element as? ACSImage else {
             logError("Element is not of type ACSImage")

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -33,9 +33,6 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             guard index > 0, (column.getSpacing() != .none || column.getSeparator()), !column.getItems().isEmpty else {
                 columnSetView.addView(columnView, in: gravityArea)
                 BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column, parentElement: columnSet)
-                let heightConstraint = columnView.heightAnchor.constraint(equalTo: columnSetView.heightAnchor)
-                heightConstraint.priority = .defaultLow
-                heightConstraint.isActive = true
                 continue
             }
             let wrappingView = ACRContentStackView(style: column.getStyle(), hostConfig: hostConfig)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -45,9 +45,6 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             columnView.trailingAnchor.constraint(equalTo: wrappingView.trailingAnchor).isActive = true
             columnSetView.addView(wrappingView, in: gravityArea)
             BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column, parentElement: columnSet)
-            let heightConstraint = columnView.heightAnchor.constraint(equalTo: columnSetView.heightAnchor)
-            heightConstraint.priority = .defaultLow
-            heightConstraint.isActive = true
         }
         
         // Add SelectAction

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -33,6 +33,9 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             guard index > 0, (column.getSpacing() != .none || column.getSeparator()), !column.getItems().isEmpty else {
                 columnSetView.addView(columnView, in: gravityArea)
                 BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column, parentElement: columnSet)
+                let heightConstraint = columnView.heightAnchor.constraint(equalTo: columnSetView.heightAnchor)
+                heightConstraint.priority = .defaultLow
+                heightConstraint.isActive = true
                 continue
             }
             let wrappingView = ACRContentStackView(style: column.getStyle(), hostConfig: hostConfig)
@@ -45,6 +48,9 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             columnView.trailingAnchor.constraint(equalTo: wrappingView.trailingAnchor).isActive = true
             columnSetView.addView(wrappingView, in: gravityArea)
             BaseCardElementRenderer.shared.configBleed(collectionView: columnView, parentView: columnSetView, with: hostConfig, element: column, parentElement: columnSet)
+            let heightConstraint = columnView.heightAnchor.constraint(equalTo: columnSetView.heightAnchor)
+            heightConstraint.priority = .defaultLow
+            heightConstraint.isActive = true
         }
         
         // Add SelectAction

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -43,7 +43,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         
         // Setting up content holder view
-        let wrappingView = ACRContentHoldingView(imageProperties: imageProperties, imageView: imageView, viewgroup: rootView)
+        let wrappingView = ACRImageWrappingView(imageProperties: imageProperties, imageView: imageView, viewgroup: rootView)
         wrappingView.translatesAutoresizingMaskIntoConstraints = false
     
         // Background color attribute
@@ -96,7 +96,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
     }
     
     func configUpdateForImage(image: NSImage?, imageView: NSImageView) {
-        guard let superView = imageView.superview as? ACRContentHoldingView, let imageSize = image?.absoluteSize else {
+        guard let superView = imageView.superview as? ACRImageWrappingView, let imageSize = image?.absoluteSize else {
                 logError("superView or image is nil")
                 return
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -74,7 +74,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             }
         }
     
-        let imagePriority = NSLayoutConstraint.Priority.defaultHigh // TODO: Possible need to revisit this
+        let imagePriority = NSLayoutConstraint.Priority.defaultHigh
         if imageProperties.acsImageSize != ACSImageSize.stretch {
             imageView.setContentHuggingPriority(imagePriority, for: .horizontal)
             imageView.setContentHuggingPriority(.defaultHigh, for: .vertical)
@@ -109,7 +109,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         let cgSize = imageProperties.contentSize
         superView.isImageSet = true
         
-        let priority = NSLayoutConstraint.Priority.defaultHigh // TODO Need to revisit this for a more generalised logic
+        let priority = NSLayoutConstraint.Priority.defaultHigh
         
         var constraints: [NSLayoutConstraint] = []
         
@@ -123,19 +123,11 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         if !imageProperties.hasExplicitDimensions {
             constraints.append(imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor, multiplier: cgSize.width / cgSize.height, constant: 0))
             constraints.append(imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: cgSize.height / cgSize.width, constant: 0))
-            constraints[2].priority = priority + 2
-            constraints[3].priority = priority + 2
         }
         
         NSLayoutConstraint.activate(constraints)
                     
         superView.invalidateIntrinsicContentSize()
-    }
-    
-    func getImageViewLayoutPriority(_ wrappingView: NSView) -> NSLayoutConstraint.Priority {
-        let ACRColumnWidthPriorityStretch = 249
-        let priority = wrappingView.contentHuggingPriority(for: .horizontal)
-        return (Int(priority.rawValue) > ACRColumnWidthPriorityStretch) ? NSLayoutConstraint.Priority.defaultHigh : priority
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -25,7 +25,7 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
         
         rootView.registerImageHandlingView(imageView, for: url)
       
-        let imageProperties = ACRImageProperties(element: imageElement, config: hostConfig, image: imageView.image, parentView: parentView)
+        let imageProperties = ACRImageProperties(element: imageElement, config: hostConfig, parentView: parentView)
         let cgsize = imageProperties.contentSize
 
         // Setting up ImageView based on Image Properties
@@ -90,7 +90,6 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
             wrappingView.isPersonStyle = true
         }
         
-        wrappingView.isVisible = imageElement.getIsVisible()
         wrappingView.setupSelectAction(imageElement.getSelectAction(), rootView: rootView)
         
         return wrappingView

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -71,7 +71,7 @@ class ACRColumnView: ACRContentStackView {
         // Because - column can be empty                        -> should have zero content size
         //         - image can have dimensions less than 30 pts -> should match image content size
         let contentStackView = subview as? ACRContentStackView
-        if !(contentStackView?.arrangedSubviews.first is ACRContentHoldingView || subview is ACRContentHoldingView) {
+        if !(contentStackView?.arrangedSubviews.first is ACRImageWrappingView || subview is ACRImageWrappingView) {
             minWidthConstraint.isActive = true
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
@@ -71,6 +71,8 @@ class ACRContentHoldingView: NSView, SelectActionHandlingProtocol {
             } else {
                 widthAnchor.constraint(equalTo: superView.widthAnchor).isActive = true
             }
+        } else {
+            widthAnchor.constraint(equalTo: superView.widthAnchor).isActive = true
         }
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
@@ -51,15 +51,8 @@ class ACRImageWrappingView: NSView, SelectActionHandlingProtocol {
     
     override func viewDidMoveToSuperview() {
         super.viewDidMoveToSuperview()
-        guard let hasExpilicitDimension = imageProperties?.hasExplicitDimensions else {
-            // assuming no explicit pixel height and width is provided when imageProperties not set
-            setWidthConstraintWithSuperView()
-            return
-        }
-        
-        if !hasExpilicitDimension {
-            setWidthConstraintWithSuperView()
-        }
+        guard let hasExpilicitDimension = imageProperties?.hasExplicitDimensions, !hasExpilicitDimension else { return }
+        setWidthConstraintWithSuperView()
     }
 
     private func setWidthConstraintWithSuperView() {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentHoldingView.swift
@@ -1,7 +1,7 @@
 import AdaptiveCards_bridge
 import AppKit
 
-class ACRContentHoldingView: NSView, SelectActionHandlingProtocol {
+class ACRImageWrappingView: NSView, SelectActionHandlingProtocol {
     private weak var _viewgroup: ACRContentStackView?
     private weak var _imageViewHeightConstraint: NSLayoutConstraint?
     private weak var _heightConstraint: NSLayoutConstraint?
@@ -94,13 +94,13 @@ class ACRContentHoldingView: NSView, SelectActionHandlingProtocol {
     
     private var previousBackgroundColor: CGColor?
     override func mouseEntered(with event: NSEvent) {
-        guard let columnView = event.trackingArea?.owner as? ACRContentHoldingView, target != nil else { return }
+        guard let columnView = event.trackingArea?.owner as? ACRImageWrappingView, target != nil else { return }
         previousBackgroundColor = columnView.layer?.backgroundColor
         columnView.layer?.backgroundColor = ColorUtils.hoverColorOnMouseEnter().cgColor
     }
     
     override func mouseExited(with event: NSEvent) {
-        guard let columnView = event.trackingArea?.owner as? ACRContentHoldingView, target != nil else { return }
+        guard let columnView = event.trackingArea?.owner as? ACRImageWrappingView, target != nil else { return }
         columnView.layer?.backgroundColor = previousBackgroundColor ?? .clear
     }
  }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
@@ -78,6 +78,23 @@ class ImageRendererTests: XCTestCase {
         XCTAssertEqual(contentView.imageProperties?.contentSize.width, CGFloat(truncating: width))
     }
     
+    func testRendererSetsPixelHeight() {
+        let height : NSNumber = 50
+        fakeImageView = .make(pixelHeight: height)
+        
+        let contentView = renderImageView()
+        XCTAssertEqual(contentView.imageProperties?.contentSize.height, CGFloat(truncating: height))
+    }
+    
+    func testRendererSetsExplicitDimensionsWhenImageSizeIsAlsoGiven() {
+        let width : NSNumber = 50
+        fakeImageView = .make(imageSize: .large, pixelWidth: width)
+        
+        let contentView = renderImageView()
+        XCTAssertEqual(contentView.imageProperties?.contentSize.width, CGFloat(truncating: width))
+    }
+    
+    
     func testRendererSetsExplicitDimensions() {
         let height : NSNumber = 100
         fakeImageView = .make(pixelHeight: height)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ImageRendererTests.swift
@@ -86,7 +86,7 @@ class ImageRendererTests: XCTestCase {
         XCTAssertEqual(contentView.imageProperties?.contentSize.height, CGFloat(truncating: height))
     }
     
-    func testRendererSetsExplicitDimensionsWhenImageSizeIsAlsoGiven() {
+    func testRendererSetsExplicitWidthWhenImageSizeIsAlsoGiven() {
         let width : NSNumber = 50
         fakeImageView = .make(imageSize: .large, pixelWidth: width)
         
@@ -94,6 +94,23 @@ class ImageRendererTests: XCTestCase {
         XCTAssertEqual(contentView.imageProperties?.contentSize.width, CGFloat(truncating: width))
     }
     
+    func testRendererSetsExplicitHeightWhenImageSizeIsAlsoGiven() {
+        let height : NSNumber = 50
+        fakeImageView = .make(imageSize: .large, pixelHeight: height)
+        
+        let contentView = renderImageView()
+        XCTAssertEqual(contentView.imageProperties?.contentSize.height, CGFloat(truncating: height))
+    }
+    
+    func testRendererSetsExplicitDimensionWhenImageSizeIsAlsoGiven() {
+        let width : NSNumber = 50
+        let height : NSNumber = 50
+        fakeImageView = .make(imageSize: .large, pixelWidth: width, pixelHeight: height)
+        
+        let contentView = renderImageView()
+        XCTAssertEqual(contentView.imageProperties?.contentSize.width, CGFloat(truncating: width))
+        XCTAssertEqual(contentView.imageProperties?.contentSize.height, CGFloat(truncating: height))
+    }
     
     func testRendererSetsExplicitDimensions() {
         let height : NSNumber = 100
@@ -103,11 +120,11 @@ class ImageRendererTests: XCTestCase {
         XCTAssertEqual(contentView.imageProperties?.hasExplicitDimensions, true)
     }
     
-    private func renderImageView() -> ACRContentHoldingView {
+    private func renderImageView() -> ACRImageWrappingView {
         let view = imageRenderer.render(element: fakeImageView, with: hostConfig, style: .default, rootView: fakeACRView, parentView: fakeACRView, inputs: [], config: .default)
         
-        XCTAssertTrue(view is ACRContentHoldingView)
-        guard let contentView = view as? ACRContentHoldingView else { fatalError() }
+        XCTAssertTrue(view is ACRImageWrappingView)
+        guard let contentView = view as? ACRImageWrappingView else { fatalError() }
         return contentView
     }
 }


### PR DESCRIPTION
## Description
1. Fix for extra padding for images when in column set. 
2. Fix for occasional broken images in multiple columns (weather card)

## Sample Card
![Screenshot 2021-04-12 at  39 04 6PM](https://user-images.githubusercontent.com/69314716/114399275-5cec1780-9bbe-11eb-9641-bb17e77d2f20.png)
![Screenshot 2021-04-12 at  39 22 6PM](https://user-images.githubusercontent.com/69314716/114399305-670e1600-9bbe-11eb-832b-826d1e6af3c4.png)
![Screenshot 2021-04-12 at  42 56 6PM](https://user-images.githubusercontent.com/69314716/114399757-e865a880-9bbe-11eb-9dbe-2998749697ac.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
