### PR TITLE
[MacOS] Added flag to prevent 1.3 properties from rendering

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -62,7 +62,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
         setupButtonConfig()
         switch AdaptiveCard.parseHostConfig(from: hostConfigString) {
         case .success(let config):
-            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemaVersion1Dot3: false))
+            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemeV1_3: false))
             // This changes the appearance of the native components depending on the hostConfig
             if #available(OSX 10.14, *) {
                 cardView.appearance = NSAppearance(named: darkTheme ? .darkAqua : .aqua)

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -62,7 +62,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
         setupButtonConfig()
         switch AdaptiveCard.parseHostConfig(from: hostConfigString) {
         case .success(let config):
-            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig))
+            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemaVersion1Dot3: false))
             // This changes the appearance of the native components depending on the hostConfig
             if #available(OSX 10.14, *) {
                 cardView.appearance = NSAppearance(named: darkTheme ? .darkAqua : .aqua)

--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -38,15 +38,16 @@ open class AdaptiveCard {
 }
 
 public struct RenderConfig {
-    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemaVersion1Dot3: false)
+    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: false)
     let isDarkMode: Bool
     let buttonConfig: ButtonConfig
-	let supportsSchemaVersion1Dot3: Bool
+    // swiftlint:disable identifier_name
+    let supportsSchemeV1_3: Bool
     
-    public init(isDarkMode: Bool, buttonConfig: ButtonConfig, supportsSchemaVersion1Dot3: Bool) {
+    public init(isDarkMode: Bool, buttonConfig: ButtonConfig, supportsSchemeV1_3: Bool) {
         self.isDarkMode = isDarkMode
         self.buttonConfig = buttonConfig
-		self.supportsSchemaVersion1Dot3 = supportsSchemaVersion1Dot3
+		self.supportsSchemeV1_3 = supportsSchemeV1_3
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -43,7 +43,7 @@ public struct RenderConfig {
     let buttonConfig: ButtonConfig
 	let supportsSchemaVersion1Dot3: Bool
     
-    public init(isDarkMode: Bool, buttonConfig: ButtonConfig) {
+    public init(isDarkMode: Bool, buttonConfig: ButtonConfig, supportsSchemaVersion1Dot3: Bool) {
         self.isDarkMode = isDarkMode
         self.buttonConfig = buttonConfig
 		self.supportsSchemaVersion1Dot3 = supportsSchemaVersion1Dot3

--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -38,13 +38,15 @@ open class AdaptiveCard {
 }
 
 public struct RenderConfig {
-    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default)
+    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemaVersion1Dot3: false)
     let isDarkMode: Bool
     let buttonConfig: ButtonConfig
+	let supportsSchemaVersion1Dot3: Bool
     
     public init(isDarkMode: Bool, buttonConfig: ButtonConfig) {
         self.isDarkMode = isDarkMode
         self.buttonConfig = buttonConfig
+		self.supportsSchemaVersion1Dot3 = supportsSchemaVersion1Dot3
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -36,7 +36,7 @@ class AdaptiveCardRenderer {
         }
         rootView.delegate = self
         rootView.resolverDelegate = self
-        if card.getVersion() == "1.3", !config.supportsSchemaVersion1Dot3 {
+        if card.getVersion() == "1.3", !config.supportsSchemeV1_3 {
             logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
         }
            

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -36,12 +36,15 @@ class AdaptiveCardRenderer {
         }
         rootView.delegate = self
         rootView.resolverDelegate = self
+        if card.getVersion() == "1.3", !config.supportsSchemaVersion1Dot3 {
+            logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
+        }
            
         for (index, element) in card.getBody().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
             let view = renderer.render(element: element, with: hostConfig, style: style, rootView: rootView, parentView: rootView, inputs: [], config: config)
-            let viewWithInheritedProperties = BaseCardElementRenderer.shared.updateView(view: view, element: element, rootView: rootView, style: style, hostConfig: hostConfig, isfirstElement: isFirstElement)
+            let viewWithInheritedProperties = BaseCardElementRenderer.shared.updateView(view: view, element: element, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
             rootView.addArrangedSubview(viewWithInheritedProperties)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: rootView, with: hostConfig, element: element, parentElement: nil)
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -36,7 +36,7 @@ class BaseCardElementRenderer {
         updatedView.isHidden = !element.getIsVisible()
         
         // Input label handling
-        if config.supportsSchemaVersion1Dot3, let inputElement = element as? ACSBaseInputElement, let label = inputElement.getLabel(), !label.isEmpty {
+        if config.supportsSchemeV1_3, let inputElement = element as? ACSBaseInputElement, let label = inputElement.getLabel(), !label.isEmpty {
             let attributedString = NSMutableAttributedString(string: label)
             if let colorHex = hostConfig.getForegroundColor(style, color: .default, isSubtle: false), let textColor = ColorUtils.color(from: colorHex) {
                 attributedString.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedString.length))

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class BaseCardElementRenderer {
     static let shared = BaseCardElementRenderer()
     
-    func updateView(view: NSView, element: ACSBaseCardElement, rootView: ACRView, style: ACSContainerStyle, hostConfig: ACSHostConfig, isfirstElement: Bool) -> NSView {
+    func updateView(view: NSView, element: ACSBaseCardElement, rootView: ACRView, style: ACSContainerStyle, hostConfig: ACSHostConfig, config: RenderConfig, isfirstElement: Bool) -> NSView {
         let updatedView = ACRContentStackView(style: style, hostConfig: hostConfig)
         
         // For Spacing
@@ -36,7 +36,7 @@ class BaseCardElementRenderer {
         updatedView.isHidden = !element.getIsVisible()
         
         // Input label handling
-        if let inputElement = element as? ACSBaseInputElement, let label = inputElement.getLabel(), !label.isEmpty {
+        if config.supportsSchemaVersion1Dot3, let inputElement = element as? ACSBaseInputElement, let label = inputElement.getLabel(), !label.isEmpty {
             let attributedString = NSMutableAttributedString(string: label)
             if let colorHex = hostConfig.getForegroundColor(style, color: .default, isSubtle: false), let textColor = ColorUtils.color(from: colorHex) {
                 attributedString.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedString.length))

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -26,7 +26,7 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
             let renderer = RendererManager.shared.renderer(for: item.getType())
             let view = renderer.render(element: item, with: hostConfig, style: style, rootView: rootView, parentView: columnView, inputs: [], config: config)
             columnView.configureColumnProperties(for: view)
-            let viewWithInheritedProperties = BaseCardElementRenderer.shared.updateView(view: view, element: item, rootView: rootView, style: style, hostConfig: hostConfig, isfirstElement: index == 0)
+            let viewWithInheritedProperties = BaseCardElementRenderer.shared.updateView(view: view, element: item, rootView: rootView, style: style, hostConfig: hostConfig, config: config, isfirstElement: index == 0)
             columnView.addArrangedSubview(viewWithInheritedProperties)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: columnView, with: hostConfig, element: item, parentElement: column)
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -29,7 +29,7 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: item.getType())
             let view = renderer.render(element: item, with: hostConfig, style: container.getStyle(), rootView: rootView, parentView: containerView, inputs: [], config: config)
-            let viewWithInheritedProperties = BaseCardElementRenderer().updateView(view: view, element: item, rootView: rootView, style: container.getStyle(), hostConfig: hostConfig, isfirstElement: isFirstElement)
+            let viewWithInheritedProperties = BaseCardElementRenderer().updateView(view: view, element: item, rootView: rootView, style: container.getStyle(), hostConfig: hostConfig, config: config, isfirstElement: isFirstElement)
             containerView.addArrangedSubview(viewWithInheritedProperties)
             BaseCardElementRenderer.shared.configBleed(collectionView: view, parentView: containerView, with: hostConfig, element: item, parentElement: container)
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -71,7 +71,7 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
             }
                     
             // apply underline to textrun
-            if config.supportsSchemaVersion1Dot3, textRun.getUnderline() {
+            if config.supportsSchemeV1_3, textRun.getUnderline() {
                 textRunContent.addAttributes([.underlineStyle: NSUnderlineStyle.single.rawValue], range: NSRange(location: 0, length: textRunContent.length))
             }
             content.append(textRunContent)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -71,7 +71,7 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
             }
                     
             // apply underline to textrun
-            if textRun.getUnderline() {
+            if config.supportsSchemaVersion1Dot3, textRun.getUnderline() {
                 textRunContent.addAttributes([.underlineStyle: NSUnderlineStyle.single.rawValue], range: NSRange(location: 0, length: textRunContent.length))
             }
             content.append(textRunContent)

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
@@ -7,6 +7,7 @@ class RichTextBlockRendererTests: XCTestCase {
     private var richTextBlock: FakeRichTextBlock!
     private var richTextBlockRenderer: RichTextBlockRenderer!
     private let sampleText = "Hello world!"
+    private let renderConfig: RenderConfig = .default
     
     
     override func setUpWithError() throws {
@@ -58,7 +59,9 @@ class RichTextBlockRendererTests: XCTestCase {
         richTextBlock = .make(textRun: textRun)
         let textView = renderTextView()
         
-        XCTAssert(isStringAttributePresent(attrString: textView.attributedString(), attr: .underlineStyle))
+        if renderConfig.supportsSchemaVersion1Dot3 {
+            XCTAssert(isStringAttributePresent(attrString: textView.attributedString(), attr: .underlineStyle))
+        }
     }
     
     func testRendererSetsStrikethrough() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/RichTextBlockRendererTest.swift
@@ -59,7 +59,7 @@ class RichTextBlockRendererTests: XCTestCase {
         richTextBlock = .make(textRun: textRun)
         let textView = renderTextView()
         
-        if renderConfig.supportsSchemaVersion1Dot3 {
+        if renderConfig.supportsSchemeV1_3 {
             XCTAssert(isStringAttributePresent(attrString: textView.attributedString(), attr: .underlineStyle))
         }
     }


### PR DESCRIPTION
## Description
Since there are certain 1.3 properties which are implemented in Mac renderer, to maintain parity with Windows, add flags, to prevent those properties from having any effect.

## Sample Card

Removed underline property
![image](https://user-images.githubusercontent.com/78855675/114359494-aa05c480-9b91-11eb-8fca-47f9a08d7d8e.png)

Removed labels from inputs
![image](https://user-images.githubusercontent.com/78855675/114359783-f18c5080-9b91-11eb-803b-09eab35ecb88.png)




## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
