### PR TITLE
[MacOS]Min-height fix for ColumnSet

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ColumnSetMinHeight.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ColumnSetMinHeight.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.2",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "style": "emphasis",
+      "minHeight": "200px",
+      "columns": [
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "TextBlock",
+              "wrap": true,
+              "text": "This column set has a minimum height of 200px"
+            }
+          ]
+        },
+        {
+          "type": "Column",
+          "items": [
+            {
+              "type": "FactSet",
+              "facts": [
+                {
+                  "title": "ColumnSet",
+                  "value": "minHeight: 200px"
+                },
+                {
+                  "title": "Column",
+                  "value": "minHeight: not specified"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -486,6 +486,8 @@
 		2910CF112600D2CC000910C8 /* ActionSetRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2910CF102600D2CC000910C8 /* ActionSetRendererTests.swift */; };
 		2910CF162600D610000910C8 /* FakeSubmitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2910CF152600D610000910C8 /* FakeSubmitAction.swift */; };
 		29430A5C25F216AA00CBA72E /* ContainerRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29430A5B25F216AA00CBA72E /* ContainerRenderer.swift */; };
+		2982B3F72628933C00E7561C /* BaseCardElementRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2982B3F62628933C00E7561C /* BaseCardElementRendererTests.swift */; };
+		2982B3FF26289F1700E7561C /* FakeBackgroundImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2982B3FE26289F1700E7561C /* FakeBackgroundImage.swift */; };
 		299DE17C26048FBB00605DAD /* ActionsRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299DE17B26048FBB00605DAD /* ActionsRendererTests.swift */; };
 		29BA82D725E265F4000B7578 /* ChoiceSetInputRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BA82D625E265F4000B7578 /* ChoiceSetInputRenderer.swift */; };
 		29C3AD38260C7C6A00467069 /* BleedUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C3AD37260C7C6A00467069 /* BleedUtils.swift */; };
@@ -1034,6 +1036,8 @@
 		2910CF102600D2CC000910C8 /* ActionSetRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSetRendererTests.swift; sourceTree = "<group>"; };
 		2910CF152600D610000910C8 /* FakeSubmitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeSubmitAction.swift; sourceTree = "<group>"; };
 		29430A5B25F216AA00CBA72E /* ContainerRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerRenderer.swift; sourceTree = "<group>"; };
+		2982B3F62628933C00E7561C /* BaseCardElementRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCardElementRendererTests.swift; sourceTree = "<group>"; };
+		2982B3FE26289F1700E7561C /* FakeBackgroundImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeBackgroundImage.swift; sourceTree = "<group>"; };
 		299DE17B26048FBB00605DAD /* ActionsRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsRendererTests.swift; sourceTree = "<group>"; };
 		29BA82D625E265F4000B7578 /* ChoiceSetInputRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceSetInputRenderer.swift; sourceTree = "<group>"; };
 		29C3AD37260C7C6A00467069 /* BleedUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BleedUtils.swift; sourceTree = "<group>"; };
@@ -1326,6 +1330,7 @@
 				082E59A82604E76E00741958 /* FakeShowCardAction.swift */,
 				082E59AD2604E96E00741958 /* FakeAdaptiveCard.swift */,
 				08FFAC312608DBCA00296D62 /* FakeOpenURLAction.swift */,
+				2982B3FE26289F1700E7561C /* FakeBackgroundImage.swift */,
 			);
 			path = Fakes;
 			sourceTree = "<group>";
@@ -1352,6 +1357,7 @@
 				299DE17B26048FBB00605DAD /* ActionsRendererTests.swift */,
 				082E59B22604EE1F00741958 /* ActionShowCardRendererTests.swift */,
 				08FFAC2C2608DB6B00296D62 /* ActionOpenURLRendererTests.swift */,
+				2982B3F62628933C00E7561C /* BaseCardElementRendererTests.swift */,
 			);
 			path = Renderers;
 			sourceTree = "<group>";
@@ -2320,6 +2326,7 @@
 				082D913425D67455000226C4 /* TextBlockRendererTests.swift in Sources */,
 				2871B11825DD20A30040AB27 /* FakeTextInput.swift in Sources */,
 				28CE1A7025E4B96300BFCFD9 /* FactSetRendererTest.swift in Sources */,
+				2982B3F72628933C00E7561C /* BaseCardElementRendererTests.swift in Sources */,
 				29050C4025DA909000AF3CA9 /* FakeInputToggle.swift in Sources */,
 				29F712EE25F73A360052DC41 /* FakeContainer.swift in Sources */,
 				08299E3E25AF254000799C66 /* AdaptiveCardsTests.swift in Sources */,
@@ -2329,6 +2336,7 @@
 				2806E8F62608886F00CF7A40 /* ActionSubmitRendererTests.swift in Sources */,
 				29E8DF8525E81E5A000EC12F /* ChoiceSetInputRendererTests.swift in Sources */,
 				2910CF162600D610000910C8 /* FakeSubmitAction.swift in Sources */,
+				2982B3FF26289F1700E7561C /* FakeBackgroundImage.swift in Sources */,
 				13C41B0925F257C3008A1F2E /* FakeInputTime.swift in Sources */,
 				2871B13F25DD41D80040AB27 /* InputNumberRendererTest.swift in Sources */,
 				0801EDB925F78EC800D64C86 /* FakeColumn.swift in Sources */,

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -20,14 +20,12 @@ class BaseCardElementRenderer {
             }
         }
         
-        if let collectionElement = element as? ACSCollectionTypeElement {
+        if let collectionElement = element as? ACSCollectionTypeElement, let contentStackView = view as? ACRContentStackView {
             if let columnView = view as? ACRColumnView, let backgroundImage = collectionElement.getBackgroundImage(), let url = backgroundImage.getUrl() {
                 columnView.setupBackgroundImageProperties(backgroundImage)
                 rootView.registerImageHandlingView(columnView.backgroundImageView, for: url)
             }
-            if let minHeight = collectionElement.getMinHeight(), let heightPt = CGFloat(exactly: minHeight), heightPt > 0 {
-                view.heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
-            }
+            contentStackView.setMinimumHeight(collectionElement.getMinHeight())
         }
         
         // For seperator

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -20,10 +20,13 @@ class BaseCardElementRenderer {
             }
         }
         
-        if let collectionElement = element as? ACSCollectionTypeElement, let columnView = view as? ACRColumnView {
-            if let backgroundImage = collectionElement.getBackgroundImage(), let url = backgroundImage.getUrl() {
+        if let collectionElement = element as? ACSCollectionTypeElement {
+            if let columnView = view as? ACRColumnView, let backgroundImage = collectionElement.getBackgroundImage(), let url = backgroundImage.getUrl() {
                 columnView.setupBackgroundImageProperties(backgroundImage)
                 rootView.registerImageHandlingView(columnView.backgroundImageView, for: url)
+            }
+            if let minHeight = collectionElement.getMinHeight(), let heightPt = CGFloat(exactly: minHeight), heightPt > 0 {
+                view.heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
             }
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -45,9 +45,6 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
         }
         containerView.wantsLayer = true
         
-        if let minHeight = container.getMinHeight(), let heightPt = CGFloat(exactly: minHeight), heightPt > 0 {
-            containerView.heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
-        }
         containerView.setVerticalHuggingPriority(1000)
         return containerView
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -119,11 +119,6 @@ class ACRColumnView: ACRContentStackView {
         manageWidth(of: stackView)
     }
     
-    func setMinimumHeight(_ height: NSNumber?) {
-        guard let height = height, let heightPt = CGFloat(exactly: height), heightPt > 0 else { return }
-        heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
-    }
-    
     private func manageWidth(of view: NSView) {
         switch columnWidth {
         case .fixed(let widthSize):

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -214,6 +214,11 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     func setVerticalHuggingPriority(_ rawValue: Float) {
         stackView.setHuggingPriority(NSLayoutConstraint.Priority(rawValue), for: .vertical)
     }
+    
+    func setMinimumHeight(_ height: NSNumber?) {
+        guard let height = height, let heightPt = CGFloat(exactly: height), heightPt > 0 else { return }
+        heightAnchor.constraint(greaterThanOrEqualToConstant: heightPt).isActive = true
+    }
 }
 
 class NoClippingLayer: CALayer {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeBackgroundImage.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeBackgroundImage.swift
@@ -1,0 +1,54 @@
+import AdaptiveCards_bridge
+
+class FakeBackgroundImage: ACSBackgroundImage {
+    private var url: String?
+    private var fillMode: ACSImageFillMode = .cover
+    private var verticalAlignment: ACSVerticalAlignment = .top
+    private var horizontalAlignment: ACSHorizontalAlignment = .center
+    
+    
+    override func getUrl() -> String? {
+        return url
+    }
+    
+    override func setUrl(_ value: String) {
+        url = value
+    }
+    
+    override func getFillMode() -> ACSImageFillMode {
+        return fillMode
+    }
+    
+    override func setFillMode(_ value: ACSImageFillMode) {
+        fillMode = value
+    }
+    
+    override func getVerticalAlignment() -> ACSVerticalAlignment {
+        return verticalAlignment
+    }
+    
+    override func setVerticalAlignment(_ value: ACSVerticalAlignment) {
+        verticalAlignment = value
+    }
+    
+    override func setHorizontalAlignment(_ value: ACSHorizontalAlignment) {
+        horizontalAlignment = value
+    }
+    
+    override func getHorizontalAlignment() -> ACSHorizontalAlignment {
+        return horizontalAlignment
+    }
+   
+}
+
+extension FakeBackgroundImage {
+    static func make(url: String = "", fillMode: ACSImageFillMode = .cover, verticalAlignment: ACSVerticalAlignment = .top, horizontalAlignment: ACSHorizontalAlignment = .center) -> FakeBackgroundImage {
+        let fakeBackgroundImage = FakeBackgroundImage()
+        fakeBackgroundImage.url = url
+        fakeBackgroundImage.fillMode = fillMode
+        fakeBackgroundImage.verticalAlignment = verticalAlignment
+        fakeBackgroundImage.horizontalAlignment = horizontalAlignment
+        return fakeBackgroundImage
+    }
+}
+

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeContainer.swift
@@ -9,6 +9,9 @@ class FakeContainer: ACSContainer {
     public var selectAction: ACSBaseActionElement?
     public var items: [ACSBaseCardElement] = []
     public var padding: Bool = false
+    public var separator: Bool = false
+    public var id: String = ""
+    public var visible: Bool = true
     
     open override func getStyle() -> ACSContainerStyle {
         return style
@@ -65,9 +68,21 @@ class FakeContainer: ACSContainer {
     open override func getPadding() -> Bool {
         return padding
     }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func getId() -> String? {
+        return id
+    }
+    
+    override func getIsVisible() -> Bool {
+        return visible
+    }
 }
 extension FakeContainer {
-    static func make(style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, bleed: Bool = false, backgroundImage: ACSBackgroundImage? = nil, minHeight: NSNumber? = 0, selectAction: ACSBaseActionElement? = .none, items: [ACSBaseCardElement] = [], padding: Bool = false) -> FakeContainer {
+    static func make(style: ACSContainerStyle = .default, verticalContentAlignment: ACSVerticalContentAlignment = .top, bleed: Bool = false, backgroundImage: ACSBackgroundImage? = nil, minHeight: NSNumber? = 0, selectAction: ACSBaseActionElement? = .none, items: [ACSBaseCardElement] = [], padding: Bool = false, separator: Bool = false, id: String = "", visible: Bool = false) -> FakeContainer {
         let fakeContainer = FakeContainer()
         fakeContainer.style = style
         fakeContainer.verticalContentAlignment = verticalContentAlignment
@@ -77,6 +92,9 @@ extension FakeContainer {
         fakeContainer.selectAction = selectAction
         fakeContainer.items = items
         fakeContainer.padding = padding
+        fakeContainer.separator = separator
+        fakeContainer.visible = visible
+        fakeContainer.id = id
         return fakeContainer
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -1,0 +1,54 @@
+@testable import AdaptiveCards
+import AdaptiveCards_bridge
+import XCTest
+
+class BaseCardElementRendererrTests: XCTestCase {
+    private var hostConfig: FakeHostConfig!
+    private var container: FakeContainer!
+    private var backgroundImage: FakeBackgroundImage!
+    private var baseCardRenderer: BaseCardElementRenderer!
+    private var containerRenderer: ContainerRenderer!
+   
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        hostConfig = .make()
+        container = .make()
+        baseCardRenderer = BaseCardElementRenderer()
+        containerRenderer = ContainerRenderer()
+        
+    }
+    
+    func testRendererSetsMinHeight() {
+        container = .make(minHeight: 200)
+        let viewWithInheritedProperties = renderBaseCardElementView()
+        XCTAssertEqual(viewWithInheritedProperties.fittingSize.height, 200)
+    }
+    
+    func testRendererSetsVisible() {
+        container = .make(visible: true)
+        let viewWithInheritedProperties = renderBaseCardElementView()
+        XCTAssertEqual(viewWithInheritedProperties.isHidden, false)
+    }
+    
+    func testRendererSetsBackgroundImage() {
+        backgroundImage = .make(url: "https://picsum.photos/200", fillMode: .repeat)
+        container = .make(backgroundImage: backgroundImage)
+        let viewWithInheritedProperties = renderBaseCardElementView()
+        guard let updatedView = viewWithInheritedProperties.arrangedSubviews[0] as? ACRColumnView else {
+            fatalError()
+        }
+        XCTAssertEqual(updatedView.backgroundImageView.fillMode, .repeat)
+    }
+    
+    
+    private func renderBaseCardElementView() -> ACRContentStackView {
+        let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
+        XCTAssertTrue(view is ACRColumnView)
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: container, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: .default, isfirstElement: true)
+        XCTAssertTrue(view is ACRContentStackView)
+        
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        return updatedView
+    }
+}

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -26,8 +26,12 @@ class BaseCardElementRendererrTests: XCTestCase {
     
     func testRendererSetsVisible() {
         container = .make(visible: true)
-        let viewWithInheritedProperties = renderBaseCardElementView()
+        var viewWithInheritedProperties = renderBaseCardElementView()
         XCTAssertEqual(viewWithInheritedProperties.isHidden, false)
+        
+        container = .make(visible: false)
+        viewWithInheritedProperties = renderBaseCardElementView()
+        XCTAssertEqual(viewWithInheritedProperties.isHidden, true)
     }
     
     func testRendererSetsBackgroundImage() {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -46,7 +46,7 @@ class BaseCardElementRendererrTests: XCTestCase {
         XCTAssertTrue(view is ACRColumnView)
         
         let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: container, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: .default, isfirstElement: true)
-        XCTAssertTrue(view is ACRContentStackView)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
         
         guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
         return updatedView

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ContainerRendererTests.swift
@@ -20,12 +20,6 @@ class ContainerRendererTests: XCTestCase {
         XCTAssertEqual(containerView.layer?.backgroundColor, nil)
     }
     
-    func testRendererSetsMinHeight() {
-        container = .make(minHeight: 200)
-        let containerView = renderContainerView()
-        XCTAssertEqual(containerView.fittingSize.height, 200)
-    }
-    
     func testRendererSetsVerticalContentAlignment() {
         container = .make(verticalContentAlignment: .top)
         var containerView = renderContainerView()


### PR DESCRIPTION
## Description
1. Added min-height for Column-set and container in baseCardElement
2. Added Test Cases for BaseCardElementRenderer

## Sample Card
<img width="375" alt="Screenshot 2021-04-15 at 10 09 40 PM" src="https://user-images.githubusercontent.com/78854679/114906103-574d3680-9e37-11eb-9b2d-5515205171d3.png">
<img width="370" alt="Screenshot 2021-04-15 at 10 09 07 PM" src="https://user-images.githubusercontent.com/78854679/114906107-5916fa00-9e37-11eb-9071-081e127f89da.png">
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
