### PR TITLE
TextBlock(Date Markdown) Bug

### DIFF
--- a/source/qml/Library/RendererQml/Utils.cpp
+++ b/source/qml/Library/RendererQml/Utils.cpp
@@ -161,6 +161,13 @@ namespace RendererQml
                         std::string format = "%x";
                         if (oneMatch[1] == "DATE")
                         {
+                            //Check if date before 1970
+                            auto date_split = Utils::splitString(oneMatch[2], '-');
+                            if (date_split.empty() || std::stoi(date_split[0])<1970)
+                            {
+                                return result;
+                            }
+
                             if (oneMatch[4] == "LONG")
                             {
                                 format = "%A, %B %d, %Y"; //There is no equivalent for C# "D" format in C++


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Assertion Failed when date markdown is passed with date before 1970


## Sample Card
![image](https://user-images.githubusercontent.com/78541663/118127621-93b08a00-b417-11eb-81a3-47e33b303147.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
