### PR TITLE
[MacOS]Hyperlink text working with renderconfig

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -62,7 +62,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
         setupButtonConfig()
         switch AdaptiveCard.parseHostConfig(from: hostConfigString) {
         case .success(let config):
-            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemeV1_3: false))
+            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemeV1_3: false, hyperlinkColorConfig: .default ))
             // This changes the appearance of the native components depending on the hostConfig
             if #available(OSX 10.14, *) {
                 cardView.appearance = NSAppearance(named: darkTheme ? .darkAqua : .aqua)

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Adaptive-card.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/Adaptive-card.json
@@ -1,0 +1,33 @@
+{
+    "type": "AdaptiveCard",
+    "version": "1.0",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Card Specifications",
+            "size": "Medium",
+            "weight": "Bolder"
+        },
+        {
+            "type": "Image",
+            "altText": "",
+            "url": "https://github.com/WebexSamples/webex-card-school/blob/master/public/images/AdaptiveCards.png?raw=true"
+        },
+        {
+            "type": "TextBlock",
+            "text": "Webex Buttons and Cards use [Microsoft's Adaptive Cards](https://adaptivecards.io/) open-source specification to define the content of the card in a JSON object. The Webex Teams clients render cards with a similar look and feel across the clients, letting you put more focus on the content and the interaction and less on the presentation.\n\n\n",
+            "wrap": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "A card is defined by creating a JSON object that describes the various Adaptive Card schema elements that should be displayed.\n",
+            "wrap": true
+        },
+        {
+            "type": "TextBlock",
+            "text": "In the next lesson, we will look a little further into what is included in the card data. ",
+            "wrap": true
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json"
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/FactSetSample.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/FactSetSample.json
@@ -7,7 +7,7 @@
             "facts": [
                 {
                     "title": "First Name followed by a long string",
-                    "value": "Mukul"
+                    "value": "Mukul [Microsoft's Adaptive Cards](https://adaptivecards.io/)"
                 },
                 {
                     "title": "Last Name",

--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -39,16 +39,18 @@ open class AdaptiveCard {
 }
 
 public struct RenderConfig {
-    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: false)
+    public static let `default` = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: false, hyperlinkColorConfig: .default)
     let isDarkMode: Bool
     let buttonConfig: ButtonConfig
     // swiftlint:disable identifier_name
     let supportsSchemeV1_3: Bool
+    let hyperlinkColorConfig: HyperlinkColorConfig
     
-    public init(isDarkMode: Bool, buttonConfig: ButtonConfig, supportsSchemeV1_3: Bool) {
+    public init(isDarkMode: Bool, buttonConfig: ButtonConfig, supportsSchemeV1_3: Bool, hyperlinkColorConfig: HyperlinkColorConfig) {
         self.isDarkMode = isDarkMode
         self.buttonConfig = buttonConfig
 		self.supportsSchemeV1_3 = supportsSchemeV1_3
+        self.hyperlinkColorConfig = hyperlinkColorConfig
     }
 }
 
@@ -90,5 +92,21 @@ public struct ButtonConfig {
         self.destructive = destructive
         self.default = `default`
         self.inline = inline
+    }
+}
+
+public struct HyperlinkColorConfig {
+    public static let `default` = HyperlinkColorConfig(foregroundColor: .systemBlue, isUnderlined: false, underlineColor: .blue, underlineStyle: .single)
+    
+    let foregroundColor: NSColor
+    let isUnderlined: Bool
+    let underlineColor: NSColor
+    let underlineStyle: NSUnderlineStyle
+    
+    public init(foregroundColor: NSColor, isUnderlined: Bool, underlineColor: NSColor, underlineStyle: NSUnderlineStyle) {
+        self.foregroundColor = foregroundColor
+        self.isUnderlined = isUnderlined
+        self.underlineColor = isUnderlined ? underlineColor : .clear
+        self.underlineStyle = underlineStyle
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -46,8 +46,20 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
                 titleView.textColor = textColor
                 valueView.textColor = textColor
                 if markdownParserResult.isHTML {
-                    attributedContent.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedContent.length))
-                    valueView.attributedTextValue = attributedContent
+                    if let attributedString = valueView.attributedTextValue {
+                        let attributedStringCopy = NSMutableAttributedString(attributedString: attributedString)
+                        attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: .longestEffectiveRangeNotRequired, using: { attributes, range, _ in
+                            if (attributes[.foregroundColor] as? NSColor) != nil {
+                                attributedStringCopy.addAttribute(.foregroundColor, value: textColor as Any, range: range)
+                            }
+                            if (attributes[NSAttributedString.Key.link ] as? NSURL) != nil {
+                                attributedStringCopy.addAttribute(.foregroundColor, value: config.hyperlinkColorConfig.foregroundColor, range: range)
+                                attributedStringCopy.addAttribute(.underlineColor, value: config.hyperlinkColorConfig.underlineColor, range: range)
+                                attributedStringCopy.addAttribute(.underlineStyle, value: config.hyperlinkColorConfig.underlineStyle.rawValue, range: range)
+                            }
+                        })
+                    valueView.attributedTextValue = attributedStringCopy
+                    }
                 }
             }
             

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -58,7 +58,7 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
                                 attributedStringCopy.addAttribute(.underlineStyle, value: config.hyperlinkColorConfig.underlineStyle.rawValue, range: range)
                             }
                         })
-                    valueView.attributedTextValue = attributedStringCopy
+                        valueView.attributedTextValue = attributedStringCopy
                     }
                 }
             }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -18,7 +18,11 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         textView.layoutManager?.usesFontLeading = false
         textView.setContentHuggingPriority(.required, for: .vertical)
         textView.backgroundColor = .clear
-        
+        textView.linkTextAttributes = [
+            NSAttributedString.Key.foregroundColor: config.hyperlinkColorConfig.foregroundColor,
+            NSAttributedString.Key.underlineColor: config.hyperlinkColorConfig.underlineColor,
+            NSAttributedString.Key.underlineStyle: config.hyperlinkColorConfig.underlineStyle.rawValue
+        ]
         // init content
         let content = NSMutableAttributedString()
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -37,6 +37,11 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         textView.textStorage?.setAttributedString(attributedString)
         textView.textContainer?.widthTracksTextView = true
         textView.backgroundColor = .clear
+        textView.linkTextAttributes = [
+            NSAttributedString.Key.foregroundColor: config.hyperlinkColorConfig.foregroundColor,
+            NSAttributedString.Key.underlineColor: config.hyperlinkColorConfig.underlineColor,
+            NSAttributedString.Key.underlineStyle: config.hyperlinkColorConfig.underlineStyle.rawValue
+        ]
         
         if attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             // Hide accessibility Element


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
![image](https://user-images.githubusercontent.com/78855675/120665825-bdeee800-c4a9-11eb-8c3b-464dcbf1fad8.png)

![image](https://user-images.githubusercontent.com/78855675/120924894-9e4b0000-c6f3-11eb-880f-e30bdecb8a02.png)
Font different for first fact and second as attributed string can use cisco font meanwhile normal text can't


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
