### PR TITLE
[MacOS]Text properties directly added to attributed String

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/BridgeUtils/BridgeTextUtils.h
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/BridgeUtils/BridgeTextUtils.h
@@ -10,6 +10,8 @@
 + (ACSMarkdownParserResult * _Nonnull)processTextFromTextBlock:(ACSTextBlock * _Nonnull)textBlock hostConfig:(ACSHostConfig * _Nonnull)config;
 + (ACSMarkdownParserResult * _Nonnull)processTextFromRichTextBlock:(ACSTextRun * _Nullable)textBlock hostConfig:(ACSHostConfig * _Nonnull)config;
 + (ACSRichTextElementProperties * _Nonnull)convertTextBlockToRichTextElementProperties:(ACSTextBlock * _Nonnull)textBlock;
++ (ACSRichTextElementProperties * _Nonnull)convertTextRunToRichTextElementProperties:(ACSTextRun * _Nonnull)textRun;
++ (ACSRichTextElementProperties * _Nonnull)convertFactToRichTextElementProperties:(ACSFact * _Nonnull)fact;
 + (ACSMarkdownParserResult * _Nonnull)processTextFromFact:(ACSFact * _Nullable)fact hostConfig:(ACSHostConfig * _Nonnull)config;
 
 @end

--- a/source/macos/AdaptiveCards/AdaptiveCards-bridge/BridgeUtils/BridgeTextUtils.mm
+++ b/source/macos/AdaptiveCards/AdaptiveCards-bridge/BridgeUtils/BridgeTextUtils.mm
@@ -12,30 +12,12 @@
 {
     auto text = [BridgeConverter getStringCpp:[textBlock getText]];
     auto language = [BridgeConverter getStringCpp:[textBlock getLanguage]];
-    auto textProperties = [BridgeTextUtils convertTextBlockToRichTextElementProperties:textBlock];
     std::shared_ptr<MarkDownParser> markDownParser = std::make_shared<MarkDownParser>([BridgeTextUtils getLocalizedDate:text language:language]);
 
     // MarkDownParser transforms text with MarkDown to a html string
     NSString *parsedString = [NSString stringWithCString:markDownParser->TransformToHtml().c_str() encoding:NSUTF8StringEncoding];
-
-    // use Apple's html rendering only if the string has markdowns
-    NSString *fontFamilyName = nil;
-
-    if ([config getFontFamily:[textBlock getFontType]]) {
-        if ([textBlock getFontType] == ACSFontTypeMonospace) {
-            fontFamilyName = @"'Courier New'";
-        } else {
-            fontFamilyName = @"'-apple-system',  'San Francisco'";
-        }
-    } else {
-        fontFamilyName = [config getFontFamily:[textBlock getFontType]];
-    }
-
-    NSString *font_style = [textProperties getItalic] ? @"italic" : @"normal";
-    // Font and text size are applied as CSS style by appending it to the html string
-    parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: %@; font-size:%@px; font-weight: %@; font-style: %@;}</style>", fontFamilyName, [config getFontSize:[textBlock getFontType] size:[textBlock getTextSize]], [config getFontWeight:[textBlock getFontType] weight:[textBlock getTextWeight]], font_style]];
-
     NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
+    
     return [[ACSMarkdownParserResult alloc] initWithParsedString:parsedString htmlData:htmlData];
 }
 
@@ -43,27 +25,10 @@
 {
     auto text = [BridgeConverter getStringCpp:[textRun getText]];
     auto language = [BridgeConverter getStringCpp:[textRun getLanguage]];
-    auto textProperties = [BridgeTextUtils convertTextRunToRichTextElementProperties:textRun];
     std::shared_ptr<MarkDownParser> markDownParser = std::make_shared<MarkDownParser>([BridgeTextUtils getLocalizedDate:text language:language]);
 
     // MarkDownParser transforms text with MarkDown to a html string
     NSString *parsedString = [NSString stringWithCString:markDownParser->TransformToHtml().c_str() encoding:NSUTF8StringEncoding];
-
-    NSString *fontFamilyName = nil;
-    if (![config getFontFamily:[textRun getFontType]]) {
-        if ([textRun getFontType] == ACSFontTypeMonospace) {
-            fontFamilyName = @"'Courier New'";
-        } else {
-            fontFamilyName = @"'-apple-system',  'San Francisco'";
-        }
-    } else {
-        fontFamilyName = [config getFontFamily:[textRun getFontType]];
-    }
-
-    NSString *font_style = [textProperties getItalic] ? @"italic" : @"normal";
-    // Font and text size are applied as CSS style by appending it to the html string
-    parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: %@; font-size:%@px; font-weight: %@; font-style: %@;}</style>", fontFamilyName, [config getFontSize:[textRun getFontType] size:[textRun getTextSize]], [config getFontWeight:[textRun getFontType] weight:[textRun getTextWeight]], font_style]];
-
     NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
 
     return [[ACSMarkdownParserResult alloc] initWithParsedString:parsedString htmlData:htmlData];
@@ -76,14 +41,9 @@
     std::shared_ptr<MarkDownParser> markDownParser = std::make_shared<MarkDownParser>([BridgeTextUtils getLocalizedDate:text language:language]);
     
     NSString *parsedString = [NSString stringWithCString:markDownParser->TransformToHtml().c_str() encoding:NSUTF8StringEncoding];
-    if (markDownParser->HasHtmlTags() || markDownParser->IsEscaped()) {
-        NSString *fontFamilyName = nil;
-        fontFamilyName = [config getFontFamily: ACSFontTypeDefault];
-        parsedString = [parsedString stringByAppendingString:[NSString stringWithFormat:@"<style>body{font-family: %@; font-size:%@px; font-weight: %@;}</style>", fontFamilyName, [config getFontSize:ACSFontTypeDefault size:ACSTextSizeDefault], [config getFontWeight:ACSFontTypeDefault weight:ACSTextWeightDefault]]];
-        NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
-        return [[ACSMarkdownParserResult alloc] initWithParsedString:parsedString htmlData:htmlData];
-    }
-    return [[ACSMarkdownParserResult alloc] initWithParsedString:parsedString htmlData:nil];
+    NSData *htmlData = [parsedString dataUsingEncoding:NSUTF16StringEncoding];
+    
+    return [[ACSMarkdownParserResult alloc] initWithParsedString:parsedString htmlData:htmlData];
 }
 
 + (ACSRichTextElementProperties * _Nonnull)convertTextRunToRichTextElementProperties:(ACSTextRun * _Nonnull)textRun
@@ -147,6 +107,19 @@
     [textProp setTextColor:[textBlock getTextColor]];
     [textProp setIsSubtle:[textBlock getIsSubtle]];
     [textProp setLanguage:[textBlock getLanguage]];
+    return textProp;
+}
+
++ (ACSRichTextElementProperties * _Nonnull)convertFactToRichTextElementProperties:(ACSFact * _Nonnull)fact
+{
+    ACSRichTextElementProperties* textProp = [[ACSRichTextElementProperties alloc] initWithRichTextElementProperties:std::make_shared<RichTextElementProperties>()];
+    [textProp setText:[fact getValue]];
+    [textProp setTextSize:ACSTextSizeDefault];
+    [textProp setTextWeight:ACSTextWeightDefault];
+    [textProp setFontType:ACSFontTypeDefault];
+    [textProp setTextColor:ACSForegroundColorDefault];
+    [textProp setIsSubtle:false];
+    [textProp setLanguage:[fact getLanguage]];
     return textProp;
 }
 @end

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -30,7 +30,8 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
         // Main loop to iterate over Array of facts
         for fact in factArray {
             let markdownParserResult = BridgeTextUtils.processText(from: fact, hostConfig: hostConfig)
-            let attributedContent = TextUtils.getMarkdownString(parserResult: markdownParserResult)
+            let markdownString = TextUtils.getMarkdownString(parserResult: markdownParserResult)
+            let attributedContent = TextUtils.addFontProperties(attributedString: markdownString, textProperties: BridgeTextUtils.convertFact(toRichTextElementProperties: fact), hostConfig: hostConfig)
             let titleView = ACRFactTextField()
             let valueView = ACRFactTextField()
             titleView.plainTextValue = fact.getTitle()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -31,7 +31,8 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
                 
             let markdownResult = BridgeTextUtils.processText(fromRichTextBlock: textRun, hostConfig: hostConfig)
             
-            let textRunContent = TextUtils.getMarkdownString(parserResult: markdownResult)
+            let markdownString = TextUtils.getMarkdownString(parserResult: markdownResult)
+            let textRunContent = TextUtils.addFontProperties(attributedString: markdownString, textProperties: BridgeTextUtils.convertTextRun(toRichTextElementProperties: textRun), hostConfig: hostConfig)
                 
             // Set paragraph style such as line break mode and alignment
             let paragraphStyle = NSMutableParagraphStyle()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -13,7 +13,8 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         textView.translatesAutoresizingMaskIntoConstraints = false
         
         let markdownResult = BridgeTextUtils.processText(from: textBlock, hostConfig: hostConfig)
-        let attributedString = TextUtils.getMarkdownString(parserResult: markdownResult)
+        let markdownString = TextUtils.getMarkdownString(parserResult: markdownResult)
+        let attributedString = TextUtils.addFontProperties(attributedString: markdownString, textProperties: BridgeTextUtils.convertTextBlock(toRichTextElementProperties: textBlock), hostConfig: hostConfig)
         
         textView.isEditable = false
         textView.textContainer?.lineFragmentPadding = 0

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
@@ -161,22 +161,21 @@ class TextUtils {
     static func addFontProperties(attributedString: NSMutableAttributedString, textProperties: ACSRichTextElementProperties, hostConfig: ACSHostConfig) -> NSMutableAttributedString {
         let content = NSMutableAttributedString(attributedString: attributedString)
         attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: .longestEffectiveRangeNotRequired, using: { attributes, range, _ in
-            if let font = attributes[.font] as? NSFont {
-                let fontWithProperties = FontUtils.getFont(for: hostConfig, with: textProperties)
-                var descriptor = font.fontDescriptor
-                
-                if descriptor.symbolicTraits.contains(.italic) {
-                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.italic)
-                } else if descriptor.symbolicTraits.contains(.bold) {
-                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.bold)
-                } else {
-                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "")
-                    let weightAttributes = CTFontDescriptorCopyAttributes(fontWithProperties.fontDescriptor)
-                    descriptor = CTFontDescriptorCreateCopyWithAttributes(descriptor, weightAttributes)
-                }
-                let newFont = NSFont(descriptor: descriptor, size: fontWithProperties.pointSize)
-                content.addAttribute(.font, value: newFont as Any, range: range)
+            guard let font = attributes[.font] as? NSFont else { return }
+            let fontWithProperties = FontUtils.getFont(for: hostConfig, with: textProperties)
+            var descriptor = font.fontDescriptor
+            
+            if descriptor.symbolicTraits.contains(.italic) {
+                descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.italic)
+            } else if descriptor.symbolicTraits.contains(.bold) {
+                descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.bold)
+            } else {
+                descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "")
+                let weightAttributes = CTFontDescriptorCopyAttributes(fontWithProperties.fontDescriptor)
+                descriptor = CTFontDescriptorCreateCopyWithAttributes(descriptor, weightAttributes)
             }
+            let newFont = NSFont(descriptor: descriptor, size: fontWithProperties.pointSize)
+            content.addAttribute(.font, value: newFont as Any, range: range)
         })
         return content
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
@@ -157,6 +157,29 @@ class TextUtils {
         }
         return content
     }
+    
+    static func addFontProperties(attributedString: NSMutableAttributedString, textProperties: ACSRichTextElementProperties, hostConfig: ACSHostConfig) -> NSMutableAttributedString {
+        let content = NSMutableAttributedString(attributedString: attributedString)
+        attributedString.enumerateAttributes(in: NSRange(location: 0, length: attributedString.length), options: .longestEffectiveRangeNotRequired, using: { attributes, range, _ in
+            if let font = attributes[.font] as? NSFont {
+                let fontWithProperties = FontUtils.getFont(for: hostConfig, with: textProperties)
+                var descriptor = font.fontDescriptor
+                
+                if descriptor.symbolicTraits.contains(.italic) {
+                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.italic)
+                } else if descriptor.symbolicTraits.contains(.bold) {
+                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "").withSymbolicTraits(.bold)
+                } else {
+                    descriptor = descriptor.withFamily(fontWithProperties.familyName ?? "")
+                    let weightAttributes = CTFontDescriptorCopyAttributes(fontWithProperties.fontDescriptor)
+                    descriptor = CTFontDescriptorCreateCopyWithAttributes(descriptor, weightAttributes)
+                }
+                let newFont = NSFont(descriptor: descriptor, size: fontWithProperties.pointSize)
+                content.addAttribute(.font, value: newFont as Any, range: range)
+            }
+        })
+        return content
+    }
 }
 
 class HostConfigUtils {


### PR DESCRIPTION
## Description
Create a function which will add style attributes directly in the markdown string instead of the html string.
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
TextBlock
![image](https://user-images.githubusercontent.com/78855675/121141947-23035e80-c859-11eb-88df-41ddad86026c.png)
![image](https://user-images.githubusercontent.com/78855675/121141995-2e568a00-c859-11eb-920c-b5dec0bda562.png)
![image](https://user-images.githubusercontent.com/78855675/121152935-429f8480-c863-11eb-9c85-f95adfedcf5a.png)

RichTectBlock
![image](https://user-images.githubusercontent.com/78855675/121153013-564aeb00-c863-11eb-82b9-9851e73bdee0.png)

FactSet:
![image](https://user-images.githubusercontent.com/78855675/121153427-af1a8380-c863-11eb-98a8-7da6ee2519a2.png)
