### PR TITLE
[SPARK-241909] Border Color and Icon changes based on UX (Windows)

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -2447,20 +2447,12 @@ namespace RendererQml
 				showCardIcon->RemoveProperty("anchors.bottom");
 				showCardIcon->Property("width", Formatter() << contentTextId << ".font.pixelSize");
 				showCardIcon->Property("height", Formatter() << contentTextId << ".font.pixelSize");
-
-				if (isIconLeftOfTitle)
-				{
-					showCardIcon->Property("anchors.verticalCenter", "parent.verticalCenter");
-				}
-				else
-				{
-					showCardIcon->Property("anchors.horizontalCenter", "parent.horizontalCenter");
-				}
+				showCardIcon->Property("anchors.verticalCenter", Formatter() << contentTextId << ".verticalCenter");
 				showCardIcon->Property("horizontalPadding", "0");
 				showCardIcon->Property("verticalPadding", "0");
 				showCardIcon->Property("icon.color", Formatter() << contentTextId << ".color");
-				showCardIcon->Property("icon.width", Formatter() << "width");
-				showCardIcon->Property("icon.height", Formatter() << "height");
+				showCardIcon->Property("icon.width", Formatter() << contentTextId << ".font.pixelSize");
+				showCardIcon->Property("icon.height", Formatter() << contentTextId << ".font.pixelSize");
 				showCardIcon->Property("icon.source", RendererQml::arrow_down_12, true);
 				showCardIcon->Property("background", showCardIconBackground->ToString());
                 textLayout->AddChild(showCardIcon);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -1188,7 +1188,7 @@ namespace RendererQml
 		}
 
 		auto highlightColor = context->GetColor(AdaptiveCards::ForegroundColor::Accent, false, false);
-		uiOuterRectangle->Property("border.color", Formatter() << checkbox.id << ".checked ? " << highlightColor << ": '767676'");
+		uiOuterRectangle->Property("border.color", Formatter() << checkbox.id << ".checked ? " << highlightColor << ": '#b0b0b0'");
 		uiOuterRectangle->Property("color", Formatter() << checkbox.id << ".checked ? " << highlightColor << " : '#ffffff'");
 
 		std::shared_ptr<QmlTag> uiInnerSegment;
@@ -2359,7 +2359,9 @@ namespace RendererQml
             auto textLayout = std::make_shared<QmlTag>("Row");
             textLayout->Property("spacing", "5");
 
+			const std::string contentTextId = buttonId + "_contentText";
             auto contentText = std::make_shared<QmlTag>("Text");
+			contentText->Property("id", contentTextId);
             if (!action->GetTitle().empty())
             {
                 contentText->Property("text", action->GetTitle(), true);
@@ -2437,7 +2439,7 @@ namespace RendererQml
             if (isShowCardButton)
             {
                 auto showCardIconItem = std::make_shared<QmlTag>("Item");
-                showCardIconItem->Property("height", Formatter() << fontSize);
+                showCardIconItem->Property("height", Formatter() << contentTextId << ".height");
                 showCardIconItem->Property("width", Formatter() << fontSize);
 
                 const std::string iconId = buttonId + "_icon";

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -78,7 +78,7 @@ namespace RendererQml
 		uiCard->Property("Layout.fillWidth", "true");
 		uiCard->Property("readonly property string bgColor", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
         uiCard->Property("color", "bgColor");
-        uiCard->Property("border.color", context->GetColor(AdaptiveCards::ForegroundColor::Default, false, false));
+        uiCard->Property("border.color", "'#B2B2B2'");
 
         const auto hasBackgroundImage = card->GetBackgroundImage() != nullptr;
 		if (hasBackgroundImage)
@@ -492,6 +492,7 @@ namespace RendererQml
 			uiTextInput->Property("selectedTextColor", "'white'");
 			uiTextInput->Property("padding", "10");
             uiTextInput->Property("color", context->GetColor(AdaptiveCards::ForegroundColor::Default, false, false));
+			uiTextInput->Property("leftPadding", "10");
 
 			if (input->GetMaxLength() > 0)
 			{
@@ -522,7 +523,7 @@ namespace RendererQml
 		//TODO: These color styling should come from css
         //TODO: Add hover effect
         backgroundTag->Property("color", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
-        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : 'grey'");
+        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : '#CCCCCC'");
 		backgroundTag->Property("border.width", "1");
 		uiTextInput->Property("background", backgroundTag->ToString());
 
@@ -633,7 +634,7 @@ namespace RendererQml
         //TODO: Add hover effect
         backgroundTag->Property("color", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
 
-		backgroundTag->Property("border.color", Formatter() << inputId << "_contentItem" << ".activeFocus? 'black' : 'grey'");
+		backgroundTag->Property("border.color", Formatter() << inputId << "_contentItem" << ".activeFocus? 'black' : '#CCCCCC'");
 
 		auto contentItemTag = std::make_shared<QmlTag>("TextField");
 		contentItemTag->Property("id", inputId + "_contentItem");
@@ -1185,8 +1186,10 @@ namespace RendererQml
 		{
 			uiOuterRectangle->Property("radius", "3");
 		}
-		uiOuterRectangle->Property("border.color", checkbox.id + ".checked ? '#0075FF' : '767676'");
-		uiOuterRectangle->Property("color", checkbox.id + ".checked ? '#0075FF' : '#ffffff'");
+
+		auto highlightColor = context->GetColor(AdaptiveCards::ForegroundColor::Accent, false, false);
+		uiOuterRectangle->Property("border.color", Formatter() << checkbox.id << ".checked ? " << highlightColor << ": '767676'");
+		uiOuterRectangle->Property("color", Formatter() << checkbox.id << ".checked ? " << highlightColor << " : '#ffffff'");
 
 		std::shared_ptr<QmlTag> uiInnerSegment;
 
@@ -1271,7 +1274,7 @@ namespace RendererQml
         backgroundTag->Property("radius", "5");
         //TODO: These color styling should come from css
         backgroundTag->Property("color", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
-        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : 'grey'");
+        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : '#CCCCCC'");
         backgroundTag->Property("border.width", "1");
         uiDateInput->Property("background", backgroundTag->ToString());
 
@@ -1670,7 +1673,7 @@ namespace RendererQml
 		//TODO: These color styling should come from css
         //TODO: Add hover effect
         backgroundTag->Property("color", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
-        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : 'grey'");
+        backgroundTag->Property("border.color", Formatter() << input->GetId() << ".activeFocus? 'black' : '#CCCCCC'");
 		backgroundTag->Property("border.width", "1");
 		uiTimeInput->Property("background", backgroundTag->ToString());
 

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -3258,7 +3258,7 @@ namespace RendererQml
 	{
 		auto cardElementType = cardElement->GetElementType();
 
-		auto isElementActionSet = cardElementType == AdaptiveSharedNamespace::CardElementType::ActionSet;
+		auto isElementActionSet = (cardElementType == AdaptiveSharedNamespace::CardElementType::ActionSet);
 		
 		if (isElementActionSet)
 		{
@@ -3269,15 +3269,12 @@ namespace RendererQml
 			{
 				if (Utils::IsInstanceOfSmart<AdaptiveCards::ShowCardAction>(action))
 				{
-					auto InternalIdPtr = std::make_shared<AdaptiveCards::InternalId>(ActionSetPtr->GetInternalId());
 					context->setLastActionSetInternalId(ActionSetPtr->GetInternalId());
 					context->setIsShowCardLastBodyElement(true);
 					return;
 				}
 			}
 		}
-
-		return;
 	}
 
 	void AdaptiveCardQmlRenderer::CheckShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context)
@@ -3290,8 +3287,6 @@ namespace RendererQml
 				return;
 			}
 		}
-
-		context->setIsShowCardInAction(false);
 	}
 
 	const std::string AdaptiveCardQmlRenderer::RemoveBottomMarginValue(std::vector<std::string> showCardsList)

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -100,8 +100,6 @@ namespace RendererQml
 
 		auto rectangle = std::make_shared<QmlTag>("Rectangle");
 		rectangle->Property("id", "adaptiveCardRectangle");
-		//Added custom property to handle bottom margin in case of showCard
-		rectangle->Property("property int bottomMargin", std::to_string(margin));
 		rectangle->Property("color", "'transparent'");
 		rectangle->Property("Layout.topMargin", "margins");
 		rectangle->Property("Layout.bottomMargin", "removeBottomMargin? 0 : margins");

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -64,8 +64,7 @@ namespace RendererQml
     {
         context->setDefaultIdName("defaultId");
 		int margin = context->GetConfig()->GetSpacing().paddingSpacing;
-		const auto adaptiveCardRectangleId = "adaptiveCardRectangle";
-
+		
         auto uiCard = std::make_shared<QmlTag>("Rectangle");
         uiCard->AddImports("import QtQuick 2.15");
         uiCard->AddImports("import QtQuick.Layouts 1.3");
@@ -100,12 +99,12 @@ namespace RendererQml
 		uiCard->AddChild(columnLayout);
 
 		auto rectangle = std::make_shared<QmlTag>("Rectangle");
-		rectangle->Property("id", adaptiveCardRectangleId);
+		rectangle->Property("id", "adaptiveCardRectangle");
 		//Added custom property to handle bottom margin in case of showCard
 		rectangle->Property("property int bottomMargin", std::to_string(margin));
 		rectangle->Property("color", "'transparent'");
 		rectangle->Property("Layout.topMargin", "margins");
-		rectangle->Property("Layout.bottomMargin", "RemoveBottomMargin? 0 : margins");
+		rectangle->Property("Layout.bottomMargin", "removeBottomMargin? 0 : margins");
 		rectangle->Property("Layout.leftMargin", "margins");
 		rectangle->Property("Layout.rightMargin", "margins");
 		rectangle->Property("Layout.fillWidth", "true");
@@ -131,9 +130,9 @@ namespace RendererQml
 		AddActions(bodyLayout, card->GetActions(), context);
         addSelectAction(uiCard, uiCard->GetId(), card->GetSelectAction(), context, hasBackgroundImage);
 
-		auto showCardsList = context->getShowCardsList();
+		auto showCardsList = context->getShowCardsLoaderIdsList();
 		auto removeBottomMarginValue = RemoveBottomMarginValue(showCardsList);
-		rectangle->Property("property bool RemoveBottomMargin", removeBottomMarginValue);
+		rectangle->Property("property bool removeBottomMargin", removeBottomMarginValue);
 
 		//Remove Top and Bottom Paddin if bleed for first and last element is true
 		rectangle = applyVerticalBleed(bodyLayout, rectangle);
@@ -283,7 +282,7 @@ namespace RendererQml
 						uiLoader->Property("width", Formatter() << uiContainer->GetProperty("id") << ".width + 2*margins - 2");
 						uiLoader->Property("readonly property bool isRemoveBottomMargin", isRemoveBottomMargin ? "true" : "false");
 
-						context->addToShowCardsList(uiLoader);
+						context->addToShowCardsLoaderIdsList(loaderId);
                         uiContainer->AddChild(uiLoader);
                     }
 
@@ -3295,13 +3294,13 @@ namespace RendererQml
 		context->setIsShowCardInAction(false);
 	}
 
-	const std::string AdaptiveCardQmlRenderer::RemoveBottomMarginValue(std::vector<std::shared_ptr<RendererQml::QmlTag>> showCardsList)
+	const std::string AdaptiveCardQmlRenderer::RemoveBottomMarginValue(std::vector<std::string> showCardsList)
 	{
 		std::string value = "";
 
-		for (auto element : showCardsList)
+		for (auto id : showCardsList)
 		{
-			value.append(Formatter() << "(" << element->GetId() << ".visible && " << element->GetId() << ".isRemoveBottomMargin) || ");
+			value.append(Formatter() << "(" << id << ".visible && " << id << ".isRemoveBottomMargin) || ");
 		}
 
 		if (value == "")

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -2307,7 +2307,8 @@ namespace RendererQml
 
             //Add button background
             auto bgRectangle = std::make_shared<QmlTag>("Rectangle");
-            bgRectangle->Property("id", Formatter() << buttonId << "_bg");
+			const std::string bgRectangleId = Formatter() << buttonId << "_bg";
+            bgRectangle->Property("id", bgRectangleId);
             bgRectangle->Property("anchors.fill", "parent");
             bgRectangle->Property("radius", Formatter() << buttonId << ".height / 2");
             bgRectangle->Property("border.width", "1");
@@ -2434,20 +2435,35 @@ namespace RendererQml
 
             if (isShowCardButton)
             {
-                auto showCardIconItem = std::make_shared<QmlTag>("Item");
-                showCardIconItem->Property("height", Formatter() << contentTextId << ".height");
-                showCardIconItem->Property("width", Formatter() << fontSize);
+                auto showCardIconBackground = std::make_shared<QmlTag>("Rectangle");
+				showCardIconBackground->Property("anchors.fill", "parent");
+				showCardIconBackground->Property("color", Formatter() << bgRectangleId << ".color");
 
-                const std::string iconId = buttonId + "_icon";
-                auto showCardIcon = std::make_shared<QmlTag>("Image");
+                const std::string iconId = Formatter() << buttonId << "_icon";
+				auto showCardIcon = GetIconTag(context);
                 showCardIcon->Property("id", iconId);
-                showCardIcon->Property("anchors.fill", "parent");
-                showCardIcon->Property("fillMode", "Image.PreserveAspectFit");
-                showCardIcon->Property("mipmap", "true");
-                showCardIcon->Property("anchors.verticalCenter", "parent.verticalCenter");
-                showCardIcon->Property("source", RendererQml::arrow_down_12, true);
-                showCardIconItem->AddChild(showCardIcon);
-                textLayout->AddChild(showCardIconItem);
+				showCardIcon->RemoveProperty("anchors.right");
+                showCardIcon->RemoveProperty("anchors.top");
+				showCardIcon->RemoveProperty("anchors.bottom");
+				showCardIcon->Property("width", Formatter() << contentTextId << ".font.pixelSize");
+				showCardIcon->Property("height", Formatter() << contentTextId << ".font.pixelSize");
+
+				if (isIconLeftOfTitle)
+				{
+					showCardIcon->Property("anchors.verticalCenter", "parent.verticalCenter");
+				}
+				else
+				{
+					showCardIcon->Property("anchors.horizontalCenter", "parent.horizontalCenter");
+				}
+				showCardIcon->Property("horizontalPadding", "0");
+				showCardIcon->Property("verticalPadding", "0");
+				showCardIcon->Property("icon.color", Formatter() << contentTextId << ".color");
+				showCardIcon->Property("icon.width", Formatter() << "width");
+				showCardIcon->Property("icon.height", Formatter() << "height");
+				showCardIcon->Property("icon.source", RendererQml::arrow_down_12, true);
+				showCardIcon->Property("background", showCardIconBackground->ToString());
+                textLayout->AddChild(showCardIcon);
             }
 
             contentLayout->AddChild(textLayout);
@@ -2566,7 +2582,7 @@ namespace RendererQml
 
 		function << "\n" << buttonElement->GetId() << ".showCard = !" << buttonElement->GetId() << ".showCard";
 		function << "\n" << buttonElement->GetId() << "_loader.visible = " << buttonElement->GetId() << ".showCard";
-		function << "\n" << buttonElement->GetId() << "_icon.source = " << buttonElement->GetId() << ".showCard ? " << "\"" << RendererQml::arrow_up_12 << "\"" << ":" << "\"" << RendererQml::arrow_down_12 << "\"";
+		function << "\n" << buttonElement->GetId() << "_icon.icon.source = " << buttonElement->GetId() << ".showCard ? " << "\"" << RendererQml::arrow_up_12 << "\"" << ":" << "\"" << RendererQml::arrow_down_12 << "\"";
 
 		return function.str();
 	}

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -64,7 +64,7 @@ namespace RendererQml
     {
         context->setDefaultIdName("defaultId");
 		int margin = context->GetConfig()->GetSpacing().paddingSpacing;
-		
+
         auto uiCard = std::make_shared<QmlTag>("Rectangle");
         uiCard->AddImports("import QtQuick 2.15");
         uiCard->AddImports("import QtQuick.Layouts 1.3");
@@ -73,7 +73,7 @@ namespace RendererQml
         context->setCardRootId(uiCard->GetId());
 		context->setCardRootElement(uiCard);
 		uiCard->Property("readonly property int margins", std::to_string(margin));
-		uiCard->AddFunctions("signal buttonClicked(var title, var type, var data)");
+        uiCard->AddFunctions("signal buttonClicked(var title, var type, var data)");
         uiCard->Property("implicitHeight", "adaptiveCardLayout.implicitHeight");
 		uiCard->Property("Layout.fillWidth", "true");
 		uiCard->Property("readonly property string bgColor", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
@@ -3258,9 +3258,7 @@ namespace RendererQml
 	{
 		auto cardElementType = cardElement->GetElementType();
 
-		auto isElementActionSet = (cardElementType == AdaptiveSharedNamespace::CardElementType::ActionSet);
-		
-		if (isElementActionSet)
+		if (cardElementType == AdaptiveSharedNamespace::CardElementType::ActionSet)
 		{
 			auto ActionSetPtr = std::dynamic_pointer_cast<AdaptiveCards::ActionSet> (cardElement);
 			auto listOfActions = ActionSetPtr->GetActions();

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -74,7 +74,8 @@ namespace RendererQml
 		context->setCardRootElement(uiCard);
 		uiCard->Property("readonly property int margins", std::to_string(margin));
         uiCard->AddFunctions("signal buttonClicked(var title, var type, var data)");
-        uiCard->Property("implicitHeight", "adaptiveCardLayout.implicitHeight");
+		//1px extra height to accomodate the border of a showCard if present at the bottom
+        uiCard->Property("implicitHeight", "adaptiveCardLayout.implicitHeight+1");
 		uiCard->Property("Layout.fillWidth", "true");
 		uiCard->Property("readonly property string bgColor", context->GetRGBColor(context->GetConfig()->GetContainerStyles().defaultPalette.backgroundColor));
         uiCard->Property("color", "bgColor");

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -2595,8 +2595,6 @@ namespace RendererQml
 			}
 		}
 
-		const int margin = context->GetConfig()->GetSpacing().paddingSpacing;
-
 		function << "\n" << buttonElement->GetId() << ".showCard = !" << buttonElement->GetId() << ".showCard";
 		function << "\n" << buttonElement->GetId() << "_loader.visible = " << buttonElement->GetId() << ".showCard";
 		function << "\n" << buttonElement->GetId() << "_icon.icon.source = " << buttonElement->GetId() << ".showCard ? " << "\"" << RendererQml::arrow_up_12 << "\"" << ":" << "\"" << RendererQml::arrow_down_12 << "\"";

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -44,7 +44,7 @@ namespace RendererQml
     protected:
         static void addSelectAction(const std::shared_ptr<QmlTag>& parent, const std::string& rectId, const std::shared_ptr<AdaptiveCards::BaseActionElement>& selectAction, const std::shared_ptr<AdaptiveRenderContext>& context, const bool hasBackgroundImage = false);
         static void addTextRunSelectActions(const std::shared_ptr<AdaptiveRenderContext>& context);
-        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context, bool isRootCard = true);
+        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context, bool isRemoveBottomMargin = true);
 		static void AddContainerElements(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& elements, std::shared_ptr<AdaptiveRenderContext> context);
 		static void AddSeparator(std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveCards::BaseCardElement> adaptiveElement, std::shared_ptr<AdaptiveRenderContext> context, const bool isShowCard = false, const std::string loaderId = "");
         static std::shared_ptr<QmlTag> AdaptiveCardRender(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, std::shared_ptr<AdaptiveRenderContext> context, bool isChildCard);
@@ -115,5 +115,9 @@ namespace RendererQml
 
         static std::shared_ptr<QmlTag> GetTextBlockMouseArea();
         static std::shared_ptr<QmlTag> getDummyElementforNumberInput(bool isTop);
+
+        static void CheckLastBodyElementIsShowCard(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::shared_ptr<AdaptiveRenderContext> context);
+        static void CheckShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
+
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -47,7 +47,7 @@ namespace RendererQml
         static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
 		static void AddContainerElements(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& elements, std::shared_ptr<AdaptiveRenderContext> context);
 		static void AddSeparator(std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveCards::BaseCardElement> adaptiveElement, std::shared_ptr<AdaptiveRenderContext> context, const bool isShowCard = false, const std::string loaderId = "");
-        static std::shared_ptr<QmlTag> AdaptiveCardRender(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, std::shared_ptr<AdaptiveRenderContext> context);
+        static std::shared_ptr<QmlTag> AdaptiveCardRender(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, std::shared_ptr<AdaptiveRenderContext> context, bool isChildCard);
 
         static std::shared_ptr<QmlTag> TextBlockRender(std::shared_ptr<AdaptiveCards::TextBlock> textBlock, std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> RichTextBlockRender(std::shared_ptr<AdaptiveCards::RichTextBlock> richTextBlock, std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -44,7 +44,7 @@ namespace RendererQml
     protected:
         static void addSelectAction(const std::shared_ptr<QmlTag>& parent, const std::string& rectId, const std::shared_ptr<AdaptiveCards::BaseActionElement>& selectAction, const std::shared_ptr<AdaptiveRenderContext>& context, const bool hasBackgroundImage = false);
         static void addTextRunSelectActions(const std::shared_ptr<AdaptiveRenderContext>& context);
-        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context, bool isRemoveBottomMargin = true);
+        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context, bool removeBottomMargin = true);
 		static void AddContainerElements(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& elements, std::shared_ptr<AdaptiveRenderContext> context);
 		static void AddSeparator(std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveCards::BaseCardElement> adaptiveElement, std::shared_ptr<AdaptiveRenderContext> context, const bool isShowCard = false, const std::string loaderId = "");
         static std::shared_ptr<QmlTag> AdaptiveCardRender(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, std::shared_ptr<AdaptiveRenderContext> context, bool isChildCard);
@@ -116,8 +116,8 @@ namespace RendererQml
         static std::shared_ptr<QmlTag> GetTextBlockMouseArea();
         static std::shared_ptr<QmlTag> getDummyElementforNumberInput(bool isTop);
 
-        static void CheckLastBodyElementIsShowCard(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::shared_ptr<AdaptiveRenderContext> context);
-        static void CheckShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
+        static void ValidateLastBodyElementIsShowCard(const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& bodyElements, std::shared_ptr<AdaptiveRenderContext> context);
+        static void ValidateShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
 
         static const std::string RemoveBottomMarginValue(std::vector<std::string> showCardsList);
 

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -44,7 +44,7 @@ namespace RendererQml
     protected:
         static void addSelectAction(const std::shared_ptr<QmlTag>& parent, const std::string& rectId, const std::shared_ptr<AdaptiveCards::BaseActionElement>& selectAction, const std::shared_ptr<AdaptiveRenderContext>& context, const bool hasBackgroundImage = false);
         static void addTextRunSelectActions(const std::shared_ptr<AdaptiveRenderContext>& context);
-        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
+        static void AddActions(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context, bool isRootCard = true);
 		static void AddContainerElements(std::shared_ptr<QmlTag> uiContainer, const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& elements, std::shared_ptr<AdaptiveRenderContext> context);
 		static void AddSeparator(std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveCards::BaseCardElement> adaptiveElement, std::shared_ptr<AdaptiveRenderContext> context, const bool isShowCard = false, const std::string loaderId = "");
         static std::shared_ptr<QmlTag> AdaptiveCardRender(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, std::shared_ptr<AdaptiveRenderContext> context, bool isChildCard);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -119,5 +119,7 @@ namespace RendererQml
         static void CheckLastBodyElementIsShowCard(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::shared_ptr<AdaptiveRenderContext> context);
         static void CheckShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
 
+        static const std::string RemoveBottomMarginValue(std::vector<std::shared_ptr<RendererQml::QmlTag>> showCardsList);
+
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -114,5 +114,6 @@ namespace RendererQml
         static std::shared_ptr<QmlTag> GetIconTag(std::shared_ptr<AdaptiveRenderContext> context);
 
         static std::shared_ptr<QmlTag> GetTextBlockMouseArea();
+        static std::shared_ptr<QmlTag> getDummyElementforNumberInput(bool isTop);
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -119,7 +119,7 @@ namespace RendererQml
         static void CheckLastBodyElementIsShowCard(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::shared_ptr<AdaptiveRenderContext> context);
         static void CheckShowCardInActions(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>>& actions, std::shared_ptr<AdaptiveRenderContext> context);
 
-        static const std::string RemoveBottomMarginValue(std::vector<std::shared_ptr<RendererQml::QmlTag>> showCardsList);
+        static const std::string RemoveBottomMarginValue(std::vector<std::string> showCardsList);
 
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -13,12 +13,12 @@ namespace RendererQml
         m_renderArgs.SetForegroundColors(m_hostConfig->GetContainerStyles().defaultPalette.foregroundColors);
     }
 
-    std::shared_ptr<QmlTag> AdaptiveRenderContext::Render(std::shared_ptr<AdaptiveCards::AdaptiveCard> element, CardRendererFunction renderFunction)
+    std::shared_ptr<QmlTag> AdaptiveRenderContext::Render(std::shared_ptr<AdaptiveCards::AdaptiveCard> element, CardRendererFunction renderFunction, bool isChildCard)
     {
         std::shared_ptr<QmlTag> qmlTagOut;
         try
         {
-            qmlTagOut = renderFunction(element, shared_from_this());
+            qmlTagOut = renderFunction(element, shared_from_this(), isChildCard);
         }
         catch (const AdaptiveFallbackException & e)
         {

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -335,7 +335,7 @@ namespace RendererQml
 
     AdaptiveCards::InternalId AdaptiveRenderContext::getLastActionSetInternalId()
     {
-        if (getIsShowCardLastBodyElement())
+        if (isShowCardLastBodyElement())
         {
             return m_LastActionSetInternalIds;
         }
@@ -345,10 +345,10 @@ namespace RendererQml
 
     void AdaptiveRenderContext::setLastActionSetInternalId(AdaptiveCards::InternalId LastActionSetInternalId)
     {
-        m_LastActionSetInternalIds=LastActionSetInternalId;
+        m_LastActionSetInternalIds = LastActionSetInternalId;
     }
 
-    const bool AdaptiveRenderContext::getIsShowCardInAction()
+    const bool AdaptiveRenderContext::isShowCardInAction()
     {
         return m_isShowCardinAction;
     }
@@ -378,7 +378,7 @@ namespace RendererQml
         m_isShowCardLastBodyElement = isShowCardLastBodyElement;
     }
 
-    const bool AdaptiveRenderContext::getIsShowCardLastBodyElement()
+    const bool AdaptiveRenderContext::isShowCardLastBodyElement()
     {
         return m_isShowCardLastBodyElement;
     }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -363,15 +363,14 @@ namespace RendererQml
         return ++m_ActionSetCounter;
     }
 
-    //ShowCards that 
-    void AdaptiveRenderContext::addToShowCardsList(std::shared_ptr<QmlTag> buttonElement)
+    void AdaptiveRenderContext::addToShowCardsLoaderIdsList(const std::string &loaderId)
     {
-        m_ShowCardsList.push_back(buttonElement);
+        m_ShowCardLoaderIdList.push_back(loaderId);
     }
 
-    const std::vector<std::shared_ptr<QmlTag>>& AdaptiveRenderContext::getShowCardsList()
+    const std::vector<std::string>& AdaptiveRenderContext::getShowCardsLoaderIdsList()
     {
-        return m_ShowCardsList;
+        return m_ShowCardLoaderIdList;
     }
 
     void AdaptiveRenderContext::setIsShowCardLastBodyElement(bool isShowCardLastBodyElement)

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -332,4 +332,39 @@ namespace RendererQml
 
         return newId;
     }
+
+    const bool AdaptiveRenderContext::GetIsShowCardLastInBody()
+    {
+        return m_isShowCardLastInBody;
+    }
+
+    void AdaptiveRenderContext::SetIsShowCardLastInBody(const bool isShowCardLastInBody)
+    {
+        m_isShowCardLastInBody = isShowCardLastInBody;
+    }
+
+    const std::shared_ptr<AdaptiveCards::InternalId> AdaptiveRenderContext::GetLastActionSetInternalId()
+    {
+        if (GetIsShowCardLastInBody())
+        {
+            return m_LastActionSetInternalId;
+        }
+        //Can we return something else here?
+        return NULL;
+    }
+
+    void AdaptiveRenderContext::SetLastActionSetInternalId(const std::shared_ptr<AdaptiveCards::InternalId> LastActionSetInternalId)
+    {
+        m_LastActionSetInternalId = LastActionSetInternalId;
+    }
+
+    const bool AdaptiveRenderContext::getIsShowCardInAction()
+    {
+        return m_isShowCardinAction;
+    }
+
+    void AdaptiveRenderContext::setIsShowCardInAction(const bool isShowCardInAction)
+    {
+        m_isShowCardinAction = isShowCardInAction;
+    }
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -333,29 +333,19 @@ namespace RendererQml
         return newId;
     }
 
-    const bool AdaptiveRenderContext::GetIsShowCardLastInBody()
+    AdaptiveCards::InternalId AdaptiveRenderContext::getLastActionSetInternalId()
     {
-        return m_isShowCardLastInBody;
-    }
-
-    void AdaptiveRenderContext::SetIsShowCardLastInBody(const bool isShowCardLastInBody)
-    {
-        m_isShowCardLastInBody = isShowCardLastInBody;
-    }
-
-    const std::shared_ptr<AdaptiveCards::InternalId> AdaptiveRenderContext::GetLastActionSetInternalId()
-    {
-        if (GetIsShowCardLastInBody())
+        if (getIsShowCardLastBodyElement())
         {
-            return m_LastActionSetInternalId;
+            return m_LastActionSetInternalIds;
         }
-        //Can we return something else here?
-        return NULL;
+
+        return AdaptiveCards::InternalId();
     }
 
-    void AdaptiveRenderContext::SetLastActionSetInternalId(const std::shared_ptr<AdaptiveCards::InternalId> LastActionSetInternalId)
+    void AdaptiveRenderContext::setLastActionSetInternalId(AdaptiveCards::InternalId LastActionSetInternalId)
     {
-        m_LastActionSetInternalId = LastActionSetInternalId;
+        m_LastActionSetInternalIds=LastActionSetInternalId;
     }
 
     const bool AdaptiveRenderContext::getIsShowCardInAction()
@@ -366,5 +356,31 @@ namespace RendererQml
     void AdaptiveRenderContext::setIsShowCardInAction(const bool isShowCardInAction)
     {
         m_isShowCardinAction = isShowCardInAction;
+    }
+
+    const int AdaptiveRenderContext::GetActionSetCounter()
+    {
+        return ++m_ActionSetCounter;
+    }
+
+    //ShowCards that 
+    void AdaptiveRenderContext::addToShowCardsList(std::shared_ptr<QmlTag> buttonElement)
+    {
+        m_ShowCardsList.push_back(buttonElement);
+    }
+
+    const std::vector<std::shared_ptr<QmlTag>>& AdaptiveRenderContext::getShowCardsList()
+    {
+        return m_ShowCardsList;
+    }
+
+    void AdaptiveRenderContext::setIsShowCardLastBodyElement(bool isShowCardLastBodyElement)
+    {
+        m_isShowCardLastBodyElement = isShowCardLastBodyElement;
+    }
+
+    const bool AdaptiveRenderContext::getIsShowCardLastBodyElement()
+    {
+        return m_isShowCardLastBodyElement;
     }
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -72,19 +72,25 @@ namespace RendererQml
 
         const std::string ConvertToValidId(const std::string& id);
 
-        const bool GetIsShowCardLastInBody();
-        void SetIsShowCardLastInBody(const bool isShowCardLastInBody);
-
         const bool getIsShowCardInAction();
         void setIsShowCardInAction(const bool isShowCardInAction);
 
-        const std::shared_ptr<AdaptiveCards::InternalId> GetLastActionSetInternalId();
-        void SetLastActionSetInternalId(const std::shared_ptr<AdaptiveCards::InternalId> LastActionSetInternalId);
+        AdaptiveCards::InternalId getLastActionSetInternalId();
+        void setLastActionSetInternalId(AdaptiveCards::InternalId LastActionSetInternalId);
+
+        const int GetActionSetCounter();
+
+        void addToShowCardsList(std::shared_ptr<QmlTag> buttonElement);
+        const std::vector<std::shared_ptr<QmlTag>>& getShowCardsList();
+
+        void setIsShowCardLastBodyElement(bool isShowCardLastBodyElement);
+        const bool getIsShowCardLastBodyElement();
 
     private:
-        bool m_isShowCardLastInBody{ false };
-        bool m_isShowCardinAction;
-        std::shared_ptr<AdaptiveCards::InternalId> m_LastActionSetInternalId;
+        bool m_isShowCardinAction{ false };
+        bool m_isShowCardLastBodyElement{ false };
+        AdaptiveCards::InternalId m_LastActionSetInternalIds;
+        std::vector<std::shared_ptr<QmlTag>> m_ShowCardsList;
 
         std::vector<AdaptiveWarning> m_warnings;
         bool m_ancestorHasFallback;
@@ -111,6 +117,7 @@ namespace RendererQml
         int m_ButtonCounter{ 0 };
         int m_SelectActionCounter{ 0 };
         int m_DefaultIdCounter{ 0 };
+        int m_ActionSetCounter{ 0 };
 
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -11,14 +11,14 @@
 namespace RendererQml
 {
     class AdaptiveRenderContext;
-    using CardRendererFunction = std::function<std::shared_ptr<QmlTag>(std::shared_ptr<AdaptiveCards::AdaptiveCard>, std::shared_ptr<AdaptiveRenderContext>)>;
+    using CardRendererFunction = std::function<std::shared_ptr<QmlTag>(std::shared_ptr<AdaptiveCards::AdaptiveCard>, std::shared_ptr<AdaptiveRenderContext>, bool)>;
 
     class AdaptiveRenderContext : public std::enable_shared_from_this<AdaptiveRenderContext>
     {
     public:
         AdaptiveRenderContext(std::shared_ptr<AdaptiveCards::HostConfig> hostConfig, std::shared_ptr<AdaptiveElementRenderers<QmlTag, AdaptiveRenderContext>> elementRenderers);
 
-        std::shared_ptr<QmlTag> Render(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, CardRendererFunction renderFunction);
+        std::shared_ptr<QmlTag> Render(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, CardRendererFunction renderFunction, bool isChildCard = false);
         std::shared_ptr<QmlTag> Render(std::shared_ptr<AdaptiveCards::BaseElement> element);
 
         const std::vector<AdaptiveWarning>& GetWarnings();

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -72,7 +72,20 @@ namespace RendererQml
 
         const std::string ConvertToValidId(const std::string& id);
 
+        const bool GetIsShowCardLastInBody();
+        void SetIsShowCardLastInBody(const bool isShowCardLastInBody);
+
+        const bool getIsShowCardInAction();
+        void setIsShowCardInAction(const bool isShowCardInAction);
+
+        const std::shared_ptr<AdaptiveCards::InternalId> GetLastActionSetInternalId();
+        void SetLastActionSetInternalId(const std::shared_ptr<AdaptiveCards::InternalId> LastActionSetInternalId);
+
     private:
+        bool m_isShowCardLastInBody{ false };
+        bool m_isShowCardinAction;
+        std::shared_ptr<AdaptiveCards::InternalId> m_LastActionSetInternalId;
+
         std::vector<AdaptiveWarning> m_warnings;
         bool m_ancestorHasFallback;
         std::shared_ptr<AdaptiveCards::HostConfig> m_hostConfig;

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -80,8 +80,8 @@ namespace RendererQml
 
         const int GetActionSetCounter();
 
-        void addToShowCardsList(std::shared_ptr<QmlTag> buttonElement);
-        const std::vector<std::shared_ptr<QmlTag>>& getShowCardsList();
+        void addToShowCardsLoaderIdsList(const std::string &loaderId);
+        const std::vector<std::string>& getShowCardsLoaderIdsList();
 
         void setIsShowCardLastBodyElement(bool isShowCardLastBodyElement);
         const bool getIsShowCardLastBodyElement();
@@ -90,7 +90,7 @@ namespace RendererQml
         bool m_isShowCardinAction{ false };
         bool m_isShowCardLastBodyElement{ false };
         AdaptiveCards::InternalId m_LastActionSetInternalIds;
-        std::vector<std::shared_ptr<QmlTag>> m_ShowCardsList;
+        std::vector<std::string> m_ShowCardLoaderIdList;
 
         std::vector<AdaptiveWarning> m_warnings;
         bool m_ancestorHasFallback;

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -72,7 +72,7 @@ namespace RendererQml
 
         const std::string ConvertToValidId(const std::string& id);
 
-        const bool getIsShowCardInAction();
+        const bool isShowCardInAction();
         void setIsShowCardInAction(const bool isShowCardInAction);
 
         AdaptiveCards::InternalId getLastActionSetInternalId();
@@ -84,7 +84,7 @@ namespace RendererQml
         const std::vector<std::string>& getShowCardsLoaderIdsList();
 
         void setIsShowCardLastBodyElement(bool isShowCardLastBodyElement);
-        const bool getIsShowCardLastBodyElement();
+        const bool isShowCardLastBodyElement();
 
     private:
         bool m_isShowCardinAction{ false };


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
- Changed border colors for all input elements and for the card

- Change choiceSet colors

- Fix TextArea placeholder padding

- Change Icon color for Input Number and Action ShowCard

- Remove Bottom Margin when showCard is opened

https://www.figma.com/file/fi0VC0FEmETIHTTWANqMqJ/Native-B-and-Cs?node-id=0%3A1

## Sample Card
Input Number Light
![image](https://user-images.githubusercontent.com/78541663/122221524-f8f01300-cece-11eb-92d9-4f2cf40efce4.png)
Input Number Dark
![image](https://user-images.githubusercontent.com/78541663/122221567-04433e80-cecf-11eb-9201-677394931188.png)

Input ChoiceSet Light
![image](https://user-images.githubusercontent.com/78541663/122221685-250b9400-cecf-11eb-8fd3-2acdb84fadf7.png)

Input ChoiceSet Dark
![image](https://user-images.githubusercontent.com/78541663/122221738-32c11980-cecf-11eb-958a-bc88efe6bd5a.png)

Action ShowCard Light
![image](https://user-images.githubusercontent.com/78541663/122739333-81403080-d2a0-11eb-9dc7-82148d2dbde0.png)

Action ShowCard Dark
![image](https://user-images.githubusercontent.com/78541663/122739376-8ac99880-d2a0-11eb-8178-8966aea3ea08.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
