### PR TITLE
[MacOS] Small bugs in MultilineInputView, and dark theme default background colors fixed

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/AdaptiveCard.swift
@@ -134,7 +134,7 @@ public struct ChoiceSetButtonConfig {
 }
 public struct InputFieldConfig {
     public static let `default` = InputFieldConfig(height: 20, leftPadding: 0, rightPadding: 0, yPadding: 0, focusRingCornerRadius: 0, borderWidth: 0.3, wantsClearButton: false, clearButtonImage: nil, calendarImage: nil, clockImage: nil, font: .systemFont(ofSize: 12), highlightedColor: .lightGray, backgroundColor: .white, borderColor: .darkGray)
-    public static let darkDefault = InputFieldConfig(height: 20, leftPadding: 0, rightPadding: 0, yPadding: 0, focusRingCornerRadius: 0, borderWidth: 0.3, wantsClearButton: false, clearButtonImage: nil, calendarImage: nil, clockImage: nil, font: .systemFont(ofSize: 12), highlightedColor: .darkGray, backgroundColor: .controlBackgroundColor, borderColor: .lightGray)
+    public static let darkDefault = InputFieldConfig(height: 20, leftPadding: 0, rightPadding: 0, yPadding: 0, focusRingCornerRadius: 0, borderWidth: 0.3, wantsClearButton: false, clearButtonImage: nil, calendarImage: nil, clockImage: nil, font: .systemFont(ofSize: 12), highlightedColor: .darkGray, backgroundColor: NSColor(white: 0.11, alpha: 1), borderColor: .lightGray)
     
     let height: CGFloat
     let leftPadding: CGFloat

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
@@ -51,11 +51,12 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
         textView.isAutomaticTextReplacementEnabled = false
         textView.smartInsertDeleteEnabled = false
         textView.font = config.font
-        textView.textContainer?.lineFragmentPadding = config.leftPadding
-        textView.wantsLayer = true
-        textView.layer?.borderColor = config.borderColor.cgColor
-        textView.layer?.borderWidth = config.borderWidth
-        textView.layer?.cornerRadius = config.focusRingCornerRadius
+        // 2 is added as padding in case the left padding is 0
+        textView.textContainer?.lineFragmentPadding = config.leftPadding + 2
+        wantsLayer = true
+        layer?.borderColor = config.borderColor.cgColor
+        layer?.borderWidth = config.borderWidth
+        layer?.cornerRadius = config.focusRingCornerRadius
         textView.backgroundColor = config.backgroundColor
         
         // For hover need tracking area
@@ -66,7 +67,8 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
     func setPlaceholder(placeholder: String) {
         let placeholderValue = NSMutableAttributedString(string: placeholder)
         placeholderValue.addAttributes([.foregroundColor: NSColor.placeholderTextColor, .font: config.font], range: NSRange(location: 0, length: placeholderValue.length))
-        textView.placeholderLeftPadding = config.leftPadding
+        // 2 is added as padding in case the left padding is 0
+        textView.placeholderLeftPadding = config.leftPadding + 2
         textView.placeholderAttrString = placeholderValue
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/MultiLineInputTextViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/MultiLineInputTextViewTests.swift
@@ -13,7 +13,7 @@ class MultiLineInputTextViewTests: XCTestCase {
     }
     
     func testLeftPadding() {
-        XCTAssertEqual(multiLineInputTextView.textView.textContainer?.lineFragmentPadding, renderConfig.inputFieldConfig.leftPadding)
+        XCTAssertEqual(multiLineInputTextView.textView.textContainer?.lineFragmentPadding, renderConfig.inputFieldConfig.leftPadding + 2)
     }
     
     func testInitialBackgroundColor() {
@@ -32,8 +32,8 @@ class MultiLineInputTextViewTests: XCTestCase {
     }
     
     func testBorderParameters() {
-        XCTAssertEqual(multiLineInputTextView.textView.layer?.borderWidth, renderConfig.inputFieldConfig.borderWidth)
-        XCTAssertEqual(multiLineInputTextView.textView.layer?.borderColor, renderConfig.inputFieldConfig.borderColor.cgColor)
+        XCTAssertEqual(multiLineInputTextView.layer?.borderWidth, renderConfig.inputFieldConfig.borderWidth)
+        XCTAssertEqual(multiLineInputTextView.layer?.borderColor, renderConfig.inputFieldConfig.borderColor.cgColor)
     }
     
     func testFocusRingCornerRadius() {


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
- Input field dark theme background colours have been changed to match the earlier defaults
- Multiline Input Text left padding for placeholder and Text padding fixed to match single line input text view
- Multiline Input Text Borders with long input are fixed

## Sample Card

**Input Field Elements with Rebrand**  
![image](https://user-images.githubusercontent.com/79969931/134373315-524d11fb-e20c-414e-8a34-434e50765373.png)

**Input Field Elements With Rebrand with placeholder**
<img width="338" alt="Screenshot 2021-09-22 at 8 59 06 PM" src="https://user-images.githubusercontent.com/79969931/134373866-86294cb3-2665-43d3-926a-2235629d693f.png">

**Input Field Elements Without Rebrand** 
<img width="422" alt="Screenshot 2021-09-22 at 8 03 56 PM" src="https://user-images.githubusercontent.com/79969931/134373974-a5652106-17d1-4825-99aa-fccc1340e2d2.png">


## How Verified
Tests have been modified to accommodate the changes to the code
