### PR TITLE
[SPARK-267453] Added Disable State for Submit Button (Windows)

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -2948,6 +2948,8 @@ namespace RendererQml
             buttonElement->Property("height", Formatter() << buttonConfig.buttonHeight);
             buttonElement->Property("Keys.onPressed", "{if(event.key === Qt.Key_Return){down=true;event.accepted=true;}}");
             buttonElement->Property("Keys.onReleased", Formatter() << "{if(event.key === Qt.Key_Return){down=false;" << buttonId << ".onReleased();event.accepted=true;}}");
+            buttonElement->Property("property bool isButtonDisabled", "false");
+            buttonElement->Property("checkable", "!isButtonDisabled");          
 
             if (isShowCardButton)
             {
@@ -3029,11 +3031,27 @@ namespace RendererQml
 
             bgRectangle->Property("border.width", Formatter() << buttonId << ".activeFocus ? 2 : 1");
 
-            if (isShowCardButton)
+            auto connectionElement = std::make_shared<QmlTag>("Connections");
+            connectionElement->Property("id", Formatter() << buttonElement->GetId() << "_connection");
+            connectionElement->Property("target", "_aModel");
+            connectionElement->AddFunctions(Formatter() << "function onEnableAdaptiveCardSubmitButton()"
+                << "\n{"
+                << "\n if (" << buttonElement->GetId() << ".isButtonDisabled) {"
+                << "\n" << buttonElement->GetId() << ".isButtonDisabled = false;"
+                << "\n}"
+                << "\n}");
+
+            if(isShowCardButton)
             {
                 bgRectangle->Property("border.color", Formatter() << buttonId << ".activeFocus ? " << context->GetHexColor(buttonConfig.borderColorFocussed) << " : " << context->GetHexColor(buttonConfig.borderColorNormal));
                 bgRectangle->Property("color", Formatter() << "(" << buttonId << ".showCard || " << buttonId << ".down )? " << context->GetHexColor(buttonConfig.buttonColorPressed) << " : (" << buttonId << ".hovered ) ? " << context->GetHexColor(buttonConfig.buttonColorHovered) << " : " << context->GetHexColor(buttonConfig.buttonColorNormal));
                 contentText->Property("color", Formatter() << "( " << buttonId << ".showCard || " << buttonId << ".hovered || " << buttonId << ".down) ? " << context->GetHexColor(buttonConfig.textColorHovered) << " : " << context->GetHexColor(buttonConfig.textColorNormal));
+            }
+            else if (action->GetElementTypeString() == "Action.Submit")
+            {
+                bgRectangle->Property("border.color", Formatter() << buttonElement->GetId() << ".isButtonDisabled ? " << context->GetHexColor(buttonConfig.buttonColorDisabled) << " : (" << buttonId << ".activeFocus && " << buttonElement->GetId() << ".isButtonDisabled ? " << context->GetHexColor(buttonConfig.borderColorFocussed) << " : " << context->GetHexColor(buttonConfig.borderColorNormal) << ")");
+                bgRectangle->Property("color", Formatter() << buttonElement->GetId() << ".isButtonDisabled ? " << context->GetHexColor(buttonConfig.buttonColorDisabled) << ": (" << buttonId << ".down ? " << context->GetHexColor(buttonConfig.buttonColorPressed) << " : (" << buttonId << ".hovered ) ? " << context->GetHexColor(buttonConfig.buttonColorHovered) << " : " << context->GetHexColor(buttonConfig.buttonColorNormal) << ")");
+                contentText->Property("color", Formatter() << buttonElement->GetId() << ".isButtonDisabled ? " << context->GetHexColor(buttonConfig.textColorDisabled) << ": (" << "( " << buttonId << ".hovered || " << buttonId << ".down )? " << context->GetHexColor(buttonConfig.textColorHovered) << " : " << context->GetHexColor(buttonConfig.textColorNormal) << ")");
             }
             else
             {
@@ -3090,6 +3108,7 @@ namespace RendererQml
             else if (action->GetElementTypeString() == "Action.Submit")
             {
                 context->addToSubmitActionButtonList(buttonElement, std::dynamic_pointer_cast<AdaptiveCards::SubmitAction>(action));
+                buttonElement->AddChild(connectionElement);
             }
             else
             {
@@ -3206,6 +3225,8 @@ namespace RendererQml
 
         function << "var paramJson = {};\n";
 
+        function << "if (!isButtonDisabled) \n{\n";
+
         if (!submitDataJson.empty() && submitDataJson != "null")
         {
             if (submitDataJson.front() == '{' && submitDataJson.back() == '}')
@@ -3228,6 +3249,8 @@ namespace RendererQml
 
         function << "var paramslist = JSON.stringify(paramJson);\n";
         function << context->getCardRootId() << ".buttonClicked(\"" << action->GetTitle() << "\", \"" << action->GetElementTypeString() << "\", paramslist);\nconsole.log(paramslist);\n";
+        function << "isButtonDisabled = true;";
+        function << "}";
 
         return function.str();
     }

--- a/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
@@ -143,6 +143,7 @@ namespace RendererQml
     struct ActionButtonConfig
     {
         std::string buttonColorNormal{ "#F2FFFFFF" };
+        std::string buttonColorDisabled{ "33FFFFFF" };
         std::string buttonColorHovered{ "#CCFFFFFF" };
         std::string buttonColorPressed{ "#B3FFFFFF" };
         std::string borderColorNormal{ "#F2FFFFFF" };
@@ -152,6 +153,7 @@ namespace RendererQml
         std::string textColorNormal{ "#F2000000" };
         std::string textColorHovered{ "#F2000000" };
         std::string textColorPressed{ "#F2000000" };
+        std::string textColorDisabled{ "#66FFFFFF" };
         int buttonRadius = 16;
         int horizotalPadding = 10;
         int verticalPadding = 5;

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -245,10 +245,10 @@ void SampleCardModel::actionSubmitButtonClicked(const QString& title, const QStr
     output.append("data: " + data);
     emit sendCardResponseToQml(output);
 
-    //To enable the button 3s after Action.Submit
+    //To enable the button 2s after Action.Submit
     std::thread thread_object([this]() {
         submit_mutex.lock();
-        std::chrono::seconds duration(3);
+        std::chrono::seconds duration(2);
         std::this_thread::sleep_for(duration);
         emit enableAdaptiveCardSubmitButton();
         submit_mutex.unlock();

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -11,6 +11,7 @@
 using namespace RendererQml;
 
 std::mutex images_mutex;
+std::mutex submit_mutex;
 
 SampleCardModel::SampleCardModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -243,6 +244,17 @@ void SampleCardModel::actionSubmitButtonClicked(const QString& title, const QStr
     output.append("Type: " + type + "\n");
     output.append("data: " + data);
     emit sendCardResponseToQml(output);
+
+    //To enable the button 3s after Action.Submit
+    std::thread thread_object([this]() {
+        submit_mutex.lock();
+        std::chrono::seconds duration(3);
+        std::this_thread::sleep_for(duration);
+        emit enableAdaptiveCardSubmitButton();
+        submit_mutex.unlock();
+        });
+
+    thread_object.detach();
 }
 
 std::pair<std::map<int, std::string>, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>>> SampleCardModel::GetCardImageUrls(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::map<int, std::string> urls, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>> showCards)
@@ -525,6 +537,7 @@ ActionButtonsConfig SampleCardModel::getActionButtonsConfig(const bool isDark)
         actionButtonsConfig.primaryColorConfig.buttonColorNormal = "#F2000000";
         actionButtonsConfig.primaryColorConfig.buttonColorHovered = "#CC000000";
         actionButtonsConfig.primaryColorConfig.buttonColorPressed = "#B3000000";
+        actionButtonsConfig.primaryColorConfig.buttonColorDisabled = "#33000000";
         actionButtonsConfig.primaryColorConfig.borderColorNormal = "#F2000000";
         actionButtonsConfig.primaryColorConfig.borderColorHovered = "#F2000000";
         actionButtonsConfig.primaryColorConfig.borderColorPressed = "#F2000000";
@@ -532,10 +545,12 @@ ActionButtonsConfig SampleCardModel::getActionButtonsConfig(const bool isDark)
         actionButtonsConfig.primaryColorConfig.textColorNormal = "#F2FFFFFF";
         actionButtonsConfig.primaryColorConfig.textColorHovered = "#F2FFFFFF";
         actionButtonsConfig.primaryColorConfig.textColorPressed = "#F2FFFFFF";
+        actionButtonsConfig.primaryColorConfig.textColorDisabled = "#66000000";
 
         actionButtonsConfig.secondaryColorConfig.buttonColorNormal = "#00000000";
         actionButtonsConfig.secondaryColorConfig.buttonColorHovered = "#12000000";
         actionButtonsConfig.secondaryColorConfig.buttonColorPressed = "#33000000";
+        actionButtonsConfig.secondaryColorConfig.buttonColorDisabled = "#33000000";
         actionButtonsConfig.secondaryColorConfig.borderColorNormal = "#4D000000";
         actionButtonsConfig.secondaryColorConfig.borderColorHovered = "#4D000000";
         actionButtonsConfig.secondaryColorConfig.borderColorPressed = "#4D000000";
@@ -543,10 +558,12 @@ ActionButtonsConfig SampleCardModel::getActionButtonsConfig(const bool isDark)
         actionButtonsConfig.secondaryColorConfig.textColorNormal = "#F2000000";
         actionButtonsConfig.secondaryColorConfig.textColorHovered = "#F2000000";
         actionButtonsConfig.secondaryColorConfig.textColorPressed = "#F2000000";
+        actionButtonsConfig.secondaryColorConfig.textColorDisabled = "#66000000";
 
         actionButtonsConfig.positiveColorConfig.buttonColorNormal = "#00000000";
         actionButtonsConfig.positiveColorConfig.buttonColorHovered = "#FF185E46";
         actionButtonsConfig.positiveColorConfig.buttonColorPressed = "#FF134231";
+        actionButtonsConfig.positiveColorConfig.buttonColorDisabled = "#33000000";
         actionButtonsConfig.positiveColorConfig.borderColorNormal = "#FF185E46";
         actionButtonsConfig.positiveColorConfig.borderColorHovered = "#FF185E46";
         actionButtonsConfig.positiveColorConfig.borderColorPressed = "#FF134231";
@@ -554,10 +571,12 @@ ActionButtonsConfig SampleCardModel::getActionButtonsConfig(const bool isDark)
         actionButtonsConfig.positiveColorConfig.textColorNormal = "#FF185E46";
         actionButtonsConfig.positiveColorConfig.textColorHovered = "#F2FFFFFF";
         actionButtonsConfig.positiveColorConfig.textColorPressed = "#F2FFFFFF";
+        actionButtonsConfig.positiveColorConfig.textColorDisabled = "#66000000";
 
         actionButtonsConfig.destructiveColorConfig.buttonColorNormal = "#00000000";
         actionButtonsConfig.destructiveColorConfig.buttonColorHovered = "#FFAB0A15";
         actionButtonsConfig.destructiveColorConfig.buttonColorPressed = "#FF780D13";
+        actionButtonsConfig.destructiveColorConfig.buttonColorDisabled = "#33000000";
         actionButtonsConfig.destructiveColorConfig.borderColorNormal = "#FFAB0A15";
         actionButtonsConfig.destructiveColorConfig.borderColorHovered = "#FFAB0A15";
         actionButtonsConfig.destructiveColorConfig.borderColorPressed = "#FF780D13";
@@ -565,6 +584,7 @@ ActionButtonsConfig SampleCardModel::getActionButtonsConfig(const bool isDark)
         actionButtonsConfig.destructiveColorConfig.textColorNormal = "#FFAB0A15";
         actionButtonsConfig.destructiveColorConfig.textColorHovered = "#F2FFFFFF";
         actionButtonsConfig.destructiveColorConfig.textColorPressed = "#F2FFFFFF";
+        actionButtonsConfig.destructiveColorConfig.textColorDisabled = "#66000000";
     }
 
     return actionButtonsConfig;

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.h
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.h
@@ -44,6 +44,7 @@ public:
 signals:
     void reloadCardOnThemeChange();
     void sendCardResponseToQml(const QString& output);
+    void enableAdaptiveCardSubmitButton();
 
 private:
     SampleCardList *mList;


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description

Added the disabled state of the Submit Button and enable it 2s after submit action. Done to maintain parity with the UCF adaptive card library

## Sample Card

https://user-images.githubusercontent.com/78541663/142005462-ac2a9e7b-82b6-4d3c-8943-e09dde44e5a3.mp4

https://user-images.githubusercontent.com/78541663/142005518-ab3d00e0-4858-4aee-99f7-eeac818dd487.mp4

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
