### PR TITLE
Card Image Height

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -108,6 +108,7 @@ namespace RendererQml
 		static const std::string getMinWidthActionSet();
 		static const std::string getMinWidthFactSet();
 		static const std::string getSelectLinkFunction();
+        static const std::string getCardHeightFunction();
 
 		template <typename CardElement>
 		static const std::shared_ptr<QmlTag> applyHorizontalBleed(CardElement cardElement, std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveRenderContext> context);


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description

Removed Empty spaces after Cards containing Images

## Sample Card

Original             	   |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/78958353/144801236-48006e87-830b-47b3-980f-9417cae86301.png) | ![image](https://user-images.githubusercontent.com/78958353/144801253-561e7eec-ccf7-47bc-b631-664dd79d1565.png)
![image](https://user-images.githubusercontent.com/78958353/144801275-59ffd922-c1d8-45f5-baf9-af70a1ef6fbe.png) | ![image](https://user-images.githubusercontent.com/78958353/144801297-94415cea-04ef-4dd1-845b-8fc72c938f73.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
