### PR TITLE
Fix for SPARK-289079 & SPARK-227200.

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -3019,6 +3019,7 @@ namespace RendererQml
         uiContainer->Property("id", id);
         uiColumnLayout->Property("id", "clayout_" + id);
         uiColumn->Property("id", "column_" + id);
+        uiColumn->Property("clip", "true");
 
         uiColumnLayout->Property("anchors.fill", "parent");
 


### PR DESCRIPTION
## Related Issue
[SPARK-227200](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-227200]),
[SPARK-227200](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-289079)

## Description
Clipping not set to true for a Column set. 

## Sample Card
Before Fix :
![SPARK-227200_before](https://user-images.githubusercontent.com/94901239/144824581-0e1f6898-aba6-448f-be4b-f17c35f6e360.png)
![SPARK-289079_before](https://user-images.githubusercontent.com/94901239/144824601-20d3c239-c16c-4665-851a-cbd8344bedc3.png)



## How Verified
Manual Verification Please find screenshot below : 
![SPARK-227200_after](https://user-images.githubusercontent.com/94901239/144824713-8dfd3ba0-0f4e-4d75-b59f-20ffbe05514c.png)
![SPARK-289079_after](https://user-images.githubusercontent.com/94901239/144824725-6f7054e5-8693-474f-b179-42383b36070e.png)

