### PR TITLE
[MacOS] Working ErrorMessage Delegates

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -66,7 +66,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
         setupInputFieldConfig()
         switch AdaptiveCard.parseHostConfig(from: hostConfigString) {
         case .success(let config):
-            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemeV1_3: false, hyperlinkColorConfig: .default, inputFieldConfig: inputFieldConfig, checkBoxButtonConfig: checkButtonConfig, radioButtonConfig: radioButtonConfig, localisedStringConfig: nil))
+            let cardView = AdaptiveCard.render(card: card, with: config, width: 350, actionDelegate: self, resourceResolver: self, config: RenderConfig(isDarkMode: darkTheme, buttonConfig: buttonConfig, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: inputFieldConfig, checkBoxButtonConfig: checkButtonConfig, radioButtonConfig: radioButtonConfig, localisedStringConfig: nil))
             
             if let renderedView = stackView.arrangedSubviews.first {
                 renderedView.removeFromSuperview()

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessageInsideContainers.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessageInsideContainers.json
@@ -1,0 +1,220 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Error Message in Container",
+            "wrap": true
+        },
+        {
+            "type": "Container",
+            "items": [
+                {
+                    "type": "Input.Text",
+                    "placeholder": "Placeholder text",
+                    "id": "text",
+                    "label": "Input.Text",
+                    "isRequired": true,
+                    "errorMessage": "Input.Text Error Message"
+                },
+                {
+                    "type": "Input.Date",
+                    "id": "date",
+                    "isRequired": true,
+                    "errorMessage": "Input.Date Error Message",
+                    "label": "Input.Date"
+                },
+                {
+                    "type": "Input.Time",
+                    "id": "time",
+                    "isRequired": true,
+                    "errorMessage": "Input.Time Error Message",
+                    "label": "Input.Time"
+                },
+                {
+                    "type": "Input.Number",
+                    "placeholder": "Placeholder text",
+                    "id": "Number",
+                    "label": "Input.Number",
+                    "isRequired": true,
+                    "errorMessage": "Input.Number Error message"
+                },
+                {
+                    "type": "Input.ChoiceSet",
+                    "choices": [
+                        {
+                            "title": "Choice 1",
+                            "value": "Choice 1"
+                        },
+                        {
+                            "title": "Choice 2",
+                            "value": "Choice 2"
+                        }
+                    ],
+                    "placeholder": "Sample",
+                    "id": "choicset compact",
+                    "label": "Compact choiceset",
+                    "isRequired": true,
+                    "errorMessage": "Input.Choicset Compac"
+                },
+                {
+                    "type": "Input.ChoiceSet",
+                    "choices": [
+                        {
+                            "title": "Choice 1",
+                            "value": "Choice 1"
+                        },
+                        {
+                            "title": "Choice 2",
+                            "value": "Choice 2"
+                        }
+                    ],
+                    "placeholder": "Placeholder text",
+                    "id": "choicset expanded",
+                    "label": "Choicset Expanded",
+                    "style": "expanded",
+                    "isRequired": true,
+                    "errorMessage": "Choiceset Expanded Error message"
+                },
+                {
+                    "type": "Input.ChoiceSet",
+                    "choices": [
+                        {
+                            "title": "Choice 1",
+                            "value": "Choice 1"
+                        },
+                        {
+                            "title": "Choice 2",
+                            "value": "Choice 2"
+                        }
+                    ],
+                    "placeholder": "Placeholder text",
+                    "id": "choicset expanded multiselect",
+                    "label": "Choicset Expanded multiselect",
+                    "style": "expanded",
+                    "isRequired": true,
+                    "errorMessage": "Choiceset Expanded multiselect Error message",
+                    "isMultiSelect": true
+                },
+                {
+                    "type": "Input.Toggle",
+                    "title": "New Input.Toggle",
+                    "id": "toggle",
+                    "label": "Input.Toggle",
+                    "isRequired": true,
+                    "errorMessage": "Input.Toggle Error message"
+                },
+                {
+                    "type": "Container",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2",
+                            "label": "Input.Text",
+                            "isRequired": true,
+                            "errorMessage": "Input.Text Error Message"
+                        },
+                        {
+                            "type": "Input.Date",
+                            "id": "date2",
+                            "isRequired": true,
+                            "errorMessage": "Input.Date Error Message",
+                            "label": "Input.Date"
+                        },
+                        {
+                            "type": "Input.Time",
+                            "id": "time2",
+                            "isRequired": true,
+                            "errorMessage": "Input.Time Error Message",
+                            "label": "Input.Time"
+                        },
+                        {
+                            "type": "Input.Number",
+                            "placeholder": "Placeholder text",
+                            "id": "Number2",
+                            "label": "Input.Number",
+                            "isRequired": true,
+                            "errorMessage": "Input.Number Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Sample",
+                            "id": "choicset compact2",
+                            "label": "Compact choiceset",
+                            "isRequired": true,
+                            "errorMessage": "Input.Choicset Compac"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choicset expanded2",
+                            "label": "Choicset Expanded",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choicset expanded multiselect2",
+                            "label": "Choicset Expanded multiselect",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded multiselect Error message",
+                            "isMultiSelect": true
+                        },
+                        {
+                            "type": "Input.Toggle",
+                            "title": "New Input.Toggle",
+                            "id": "toggle2",
+                            "label": "Input.Toggle",
+                            "isRequired": true,
+                            "errorMessage": "Input.Toggle Error message"
+                        }
+                    ],
+                    "style": "accent"
+                }
+            ],
+            "style": "good"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Submit"
+        }
+    ]
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessagesInCard.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessagesInCard.json
@@ -1,0 +1,113 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Error Messages in Card",
+            "wrap": true
+        },
+        {
+            "type": "Input.Text",
+            "placeholder": "Placeholder text",
+            "id": "text",
+            "label": "Input.Text",
+            "isRequired": true,
+            "errorMessage": "Input.Text Error Message"
+        },
+        {
+            "type": "Input.Date",
+            "id": "date",
+            "isRequired": true,
+            "errorMessage": "Input.Date Error Message",
+            "label": "Input.Date"
+        },
+        {
+            "type": "Input.Time",
+            "id": "time",
+            "isRequired": true,
+            "errorMessage": "Input.Time Error Message",
+            "label": "Input.Time"
+        },
+        {
+            "type": "Input.Number",
+            "placeholder": "Placeholder text",
+            "id": "Number",
+            "label": "Input.Number",
+            "isRequired": true,
+            "errorMessage": "Input.Number Error message"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "choices": [
+                {
+                    "title": "Choice 1",
+                    "value": "Choice 1"
+                },
+                {
+                    "title": "Choice 2",
+                    "value": "Choice 2"
+                }
+            ],
+            "placeholder": "Sample",
+            "id": "choicset compact",
+            "label": "Compact choiceset",
+            "isRequired": true,
+            "errorMessage": "Input.Choicset Compac"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "choices": [
+                {
+                    "title": "Choice 1",
+                    "value": "Choice 1"
+                },
+                {
+                    "title": "Choice 2",
+                    "value": "Choice 2"
+                }
+            ],
+            "placeholder": "Placeholder text",
+            "id": "choicset expanded",
+            "label": "Choicset Expanded",
+            "style": "expanded",
+            "isRequired": true,
+            "errorMessage": "Choiceset Expanded Error message"
+        },
+        {
+            "type": "Input.ChoiceSet",
+            "choices": [
+                {
+                    "title": "Choice 1",
+                    "value": "Choice 1"
+                },
+                {
+                    "title": "Choice 2",
+                    "value": "Choice 2"
+                }
+            ],
+            "placeholder": "Placeholder text",
+            "id": "choicset expanded multiselect",
+            "label": "Choicset Expanded multiselect",
+            "style": "expanded",
+            "isRequired": true,
+            "errorMessage": "Choiceset Expanded multiselect Error message",
+            "isMultiSelect": true
+        },
+        {
+            "type": "Input.Toggle",
+            "title": "New Input.Toggle",
+            "id": "toggle",
+            "label": "Input.Toggle",
+            "isRequired": true,
+            "errorMessage": "Input.Toggle Error message"
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Submit"
+        }
+    ]
+}

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessagesInColumns.json
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/samples/ErrorMessagesInColumns.json
@@ -1,0 +1,225 @@
+{
+    "type": "AdaptiveCard",
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "Error Messages inside Columns",
+            "wrap": true
+        },
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text1",
+                            "label": "Input.Text",
+                            "isRequired": true,
+                            "errorMessage": "Input.Text Error Message"
+                        },
+                        {
+                            "type": "Input.Date",
+                            "id": "date1",
+                            "isRequired": true,
+                            "errorMessage": "Input.Date Error Message",
+                            "label": "Input.Date"
+                        },
+                        {
+                            "type": "Input.Time",
+                            "id": "time1",
+                            "isRequired": true,
+                            "errorMessage": "Input.Time Error Message",
+                            "label": "Input.Time"
+                        },
+                        {
+                            "type": "Input.Number",
+                            "placeholder": "Placeholder text",
+                            "id": "Number1",
+                            "label": "Input.Number",
+                            "isRequired": true,
+                            "errorMessage": "Input.Number Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Sample",
+                            "id": "choicset compact1",
+                            "label": "Compact choiceset",
+                            "isRequired": true,
+                            "errorMessage": "Input.Choicset Compac"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choiceset expanded1",
+                            "label": "Choicset Expanded",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choicset expanded multiselect1",
+                            "label": "Choicset Expanded multiselect",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded multiselect Error message",
+                            "isMultiSelect": true
+                        },
+                        {
+                            "type": "Input.Toggle",
+                            "title": "New Input.Toggle",
+                            "id": "toggle1",
+                            "label": "Input.Toggle",
+                            "isRequired": true,
+                            "errorMessage": "Input.Toggle Error message"
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "stretch",
+                    "items": [
+                        {
+                            "type": "Input.Text",
+                            "placeholder": "Placeholder text",
+                            "id": "text2",
+                            "label": "Input.Text",
+                            "isRequired": true,
+                            "errorMessage": "Input.Text Error Message"
+                        },
+                        {
+                            "type": "Input.Date",
+                            "id": "date2",
+                            "isRequired": true,
+                            "errorMessage": "Input.Date Error Message",
+                            "label": "Input.Date"
+                        },
+                        {
+                            "type": "Input.Time",
+                            "id": "time2",
+                            "isRequired": true,
+                            "errorMessage": "Input.Time Error Message",
+                            "label": "Input.Time"
+                        },
+                        {
+                            "type": "Input.Number",
+                            "placeholder": "Placeholder text",
+                            "id": "Number2",
+                            "label": "Input.Number",
+                            "isRequired": true,
+                            "errorMessage": "Input.Number Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Sample",
+                            "id": "choicset compact2",
+                            "label": "Compact choiceset",
+                            "isRequired": true,
+                            "errorMessage": "Input.Choicset Compac"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choicset expanded2",
+                            "label": "Choicset Expanded",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded Error message"
+                        },
+                        {
+                            "type": "Input.ChoiceSet",
+                            "choices": [
+                                {
+                                    "title": "Choice 1",
+                                    "value": "Choice 1"
+                                },
+                                {
+                                    "title": "Choice 2",
+                                    "value": "Choice 2"
+                                }
+                            ],
+                            "placeholder": "Placeholder text",
+                            "id": "choicset expanded multiselect2",
+                            "label": "Choicset Expanded multiselect",
+                            "style": "expanded",
+                            "isRequired": true,
+                            "errorMessage": "Choiceset Expanded multiselect Error message",
+                            "isMultiSelect": true
+                        },
+                        {
+                            "type": "Input.Toggle",
+                            "title": "New Input.Toggle",
+                            "id": "toggle2",
+                            "label": "Input.Toggle",
+                            "isRequired": true,
+                            "errorMessage": "Input.Toggle Error message"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "type": "Action.Submit",
+            "title": "Submit"
+        }
+    ]
+}

--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/BaseProtocol.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/BaseProtocol.swift
@@ -31,6 +31,7 @@ protocol InputHandlingViewProtocol: NSView {
     var value: String { get }
     var key: String { get }
     var isValid: Bool { get }
+    var errorMessageHandler: ErrorMessageHandlerDelegate? { get set }
 }
 
 protocol ShowCardHandlingView: NSView {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -52,6 +52,15 @@ class BaseCardElementRenderer {
         if view is ACRContentStackView {
             view.widthAnchor.constraint(equalTo: updatedView.widthAnchor).isActive = true
         }
+        
+        if config.supportsSchemeV1_3, let inputElement = element as? ACSBaseInputElement, let errorMessage = inputElement.getErrorMessage(), !errorMessage.isEmpty {
+            updatedView.setCustomSpacing(spacing: 3, after: view)
+            updatedView.setErrorMessage(with: errorMessage)
+            if let view = view as? InputHandlingViewProtocol {
+                 view.errorMessageHandler = updatedView
+            }
+        }
+        
         return updatedView
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -53,12 +53,9 @@ class BaseCardElementRenderer {
             view.widthAnchor.constraint(equalTo: updatedView.widthAnchor).isActive = true
         }
         
-        if config.supportsSchemeV1_3, let inputElement = element as? ACSBaseInputElement, let errorMessage = inputElement.getErrorMessage(), !errorMessage.isEmpty {
-            updatedView.setCustomSpacing(spacing: 3, after: view)
-            updatedView.setErrorMessage(with: errorMessage)
-            if let view = view as? InputHandlingViewProtocol {
-                 view.errorMessageHandler = updatedView
-            }
+        if config.supportsSchemeV1_3, let inputElement = element as? ACSBaseInputElement, let view = view as? InputHandlingViewProtocol, let errorMessage = inputElement.getErrorMessage(), !errorMessage.isEmpty {
+            updatedView.setCustomSpacing(spacing: 10, after: view)
+            updatedView.setErrorMessage(with: errorMessage, for: view)
         }
         
         return updatedView

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
@@ -156,7 +156,7 @@ extension ACRNumericTextField: InputHandlingViewProtocol {
     static let MINVAL = -MAXVAL
     
     var inputValue: Double {
-        get { return stepper.doubleValue }
+        get { return textField.doubleValue }
         set {
             textField.doubleValue = newValue
             stepper.doubleValue = newValue
@@ -209,11 +209,9 @@ extension ACRNumericTextField: InputHandlingViewProtocol {
     override open func keyDown(with event: NSEvent) {
         switch Int(event.keyCode) {
         case kVK_UpArrow:
-            stepper.doubleValue += 1
-            inputValue = stepper.doubleValue
+            inputValue += 1
         case kVK_DownArrow:
-            stepper.doubleValue -= 1
-            inputValue = stepper.doubleValue
+            inputValue -= 1
         default:
             super.keyDown(with: event)
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
@@ -238,4 +238,13 @@ extension ACRNumericTextField: InputHandlingViewProtocol {
     var isValid: Bool {
         return true
     }
+    
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate? {
+        get {
+            return textField.errorMessageHandler
+        }
+        set {
+            textField.errorMessageHandler = newValue
+        }
+    }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
@@ -15,6 +15,7 @@ class ACRChoiceButton: NSView, NSTextFieldDelegate, InputHandlingViewProtocol {
     public var idString: String?
     public var valueOn: String?
     public var valueOff: String?
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate?
     
     private let buttonConfig: ChoiceSetButtonConfig?
     private let buttonType: ChoiceSetButtonType

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
@@ -15,6 +15,7 @@ class ACRChoiceSetView: NSView, InputHandlingViewProtocol {
     public var previousButton: ACRChoiceButton?
     public var wrap = false
     public var idString: String?
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate?
     
     private let renderConfig: RenderConfig
     
@@ -97,6 +98,7 @@ class ACRChoiceSetCompactView: NSPopUpButton, InputHandlingViewProtocol {
     public var idString: String?
     public var valueSelected: String?
     public var arrayValues: [String] = []
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate?
     override func viewDidMoveToSuperview() {
         guard let superview = superview else { return }
         widthAnchor.constraint(equalTo: superview.widthAnchor).isActive = true

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
@@ -16,7 +16,6 @@ class ACRChoiceSetView: NSView, InputHandlingViewProtocol {
     public var wrap = false
     public var idString: String?
     weak var errorMessageHandler: ErrorMessageHandlerDelegate?
-    private var toggleValue = false
     
     private let renderConfig: RenderConfig
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
@@ -16,6 +16,7 @@ class ACRChoiceSetView: NSView, InputHandlingViewProtocol {
     public var wrap = false
     public var idString: String?
     weak var errorMessageHandler: ErrorMessageHandlerDelegate?
+    private var toggleValue = false
     
     private let renderConfig: RenderConfig
     

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -6,6 +6,11 @@ protocol ACRContentHoldingViewProtocol {
     func applyPadding(_ padding: CGFloat)
 }
 
+protocol ErrorMessageHandlerDelegate: AnyObject {
+    func showErrorMessage(for view: NSView)
+    func hideErrorMessage(for view: NSView)
+}
+
 class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHandlingProtocol {
     private var stackViewLeadingConstraint: NSLayoutConstraint?
     private var stackViewTrailingConstraint: NSLayoutConstraint?
@@ -14,6 +19,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     
     private var currentSpacingView: SpacingView?
     private var currentSeparatorView: SpacingView?
+    private var errorMessageView: NSTextField?
     
     let style: ACSContainerStyle
     let hostConfig: ACSHostConfig
@@ -220,6 +226,18 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         layer?.backgroundColor = ColorUtils.hoverColorOnMouseEnter().cgColor
     }
     
+    func setErrorMessage(with title: String) {
+        errorMessageView = NSTextField()
+        errorMessageView?.stringValue = title
+        errorMessageView?.isHidden = false
+        errorMessageView?.isEditable = false
+        errorMessageView?.isBordered = false
+        errorMessageView?.isSelectable = true
+        
+        guard let errorMessageView = errorMessageView else { return }
+        addArrangedSubview(errorMessageView)
+    }
+    
     override func mouseExited(with event: NSEvent) {
         guard target != nil else { return }
         layer?.backgroundColor = previousBackgroundColor ?? .clear
@@ -234,6 +252,16 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     override func hitTest(_ point: NSPoint) -> NSView? {
         guard target != nil, frame.contains(point) else { return super.hitTest(point) }
         return self
+    }
+}
+
+extension ACRContentStackView: ErrorMessageHandlerDelegate {
+    func showErrorMessage(for view: NSView) {
+        errorMessageView?.isHidden = false
+    }
+    
+    func hideErrorMessage(for view: NSView) {
+        errorMessageView?.isHidden = true
     }
 }
 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -227,7 +227,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     }
     
     func setErrorMessage(with title: String, for view: InputHandlingViewProtocol) {
-        guard errorMessageView != nil else { return }
+        guard errorMessageView == nil else { return }
         let textField = NSTextField()
         textField.stringValue = title
         textField.isHidden = true

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -19,7 +19,7 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     
     private var currentSpacingView: SpacingView?
     private var currentSeparatorView: SpacingView?
-    private var errorMessageView: NSTextField?
+    private (set) var errorMessageView: NSTextField?
     
     let style: ACSContainerStyle
     let hostConfig: ACSHostConfig
@@ -226,14 +226,15 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
         layer?.backgroundColor = ColorUtils.hoverColorOnMouseEnter().cgColor
     }
     
-    func setErrorMessage(with title: String) {
+    func setErrorMessage(with title: String, for view: InputHandlingViewProtocol) {
         errorMessageView = NSTextField()
         errorMessageView?.stringValue = title
-        errorMessageView?.isHidden = false
+        errorMessageView?.isHidden = true
         errorMessageView?.isEditable = false
         errorMessageView?.isBordered = false
         errorMessageView?.isSelectable = true
-        
+        errorMessageView?.backgroundColor = .clear
+        view.errorMessageHandler = self
         guard let errorMessageView = errorMessageView else { return }
         addArrangedSubview(errorMessageView)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -7,8 +7,8 @@ protocol ACRContentHoldingViewProtocol {
 }
 
 protocol ErrorMessageHandlerDelegate: AnyObject {
-    func showErrorMessage(for view: NSView)
-    func hideErrorMessage(for view: NSView)
+    func showErrorMessage(for view: InputHandlingViewProtocol)
+    func hideErrorMessage(for view: InputHandlingViewProtocol)
 }
 
 class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHandlingProtocol {
@@ -227,16 +227,17 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
     }
     
     func setErrorMessage(with title: String, for view: InputHandlingViewProtocol) {
-        errorMessageView = NSTextField()
-        errorMessageView?.stringValue = title
-        errorMessageView?.isHidden = true
-        errorMessageView?.isEditable = false
-        errorMessageView?.isBordered = false
-        errorMessageView?.isSelectable = true
-        errorMessageView?.backgroundColor = .clear
+        guard errorMessageView != nil else { return }
+        let textField = NSTextField()
+        textField.stringValue = title
+        textField.isHidden = true
+        textField.isEditable = false
+        textField.isBordered = false
+        textField.isSelectable = true
+        textField.backgroundColor = .clear
         view.errorMessageHandler = self
-        guard let errorMessageView = errorMessageView else { return }
-        addArrangedSubview(errorMessageView)
+        addArrangedSubview(textField)
+        errorMessageView = textField
     }
     
     override func mouseExited(with event: NSEvent) {
@@ -257,11 +258,11 @@ class ACRContentStackView: NSView, ACRContentHoldingViewProtocol, SelectActionHa
 }
 
 extension ACRContentStackView: ErrorMessageHandlerDelegate {
-    func showErrorMessage(for view: NSView) {
+    func showErrorMessage(for view: InputHandlingViewProtocol) {
         errorMessageView?.isHidden = false
     }
     
-    func hideErrorMessage(for view: NSView) {
+    func hideErrorMessage(for view: InputHandlingViewProtocol) {
         errorMessageView?.isHidden = true
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -115,6 +115,15 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
         return true
     }
     
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate? {
+        get {
+            return textField.errorMessageHandler
+        }
+        set {
+            textField.errorMessageHandler = newValue
+        }
+    }
+    
     init(isTimeMode: Bool, config: RenderConfig) {
         self.isTimeMode = isTimeMode
         self.isDarkMode = config.isDarkMode

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
@@ -7,6 +7,7 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
     @IBOutlet var textView: ACRTextView!
     
     private var placeholderAttrString: NSAttributedString?
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate?
     private let config: RenderConfig
     private let inputConfig: InputFieldConfig
     var maxLen: Int = 0

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
@@ -191,7 +191,6 @@ class ACRTextField: NSTextField {
     
     private func updateClearButton() {
         clearButton.isHidden = isEmpty
-        clearButton.isHidden ? errorMessageHandler?.hideErrorMessage(for: self) : errorMessageHandler?.showErrorMessage(for: self)
     }
     
     private var wantsClearButton: Bool {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRTextField.swift
@@ -17,6 +17,7 @@ class ACRTextField: NSTextField {
     private let inputConfig: InputFieldConfig
     private let isDarkMode: Bool
     private let textFieldMode: Mode
+    weak var errorMessageHandler: ErrorMessageHandlerDelegate?
     
     init(dateTimeFieldWith config: RenderConfig) {
         self.config = config
@@ -190,6 +191,7 @@ class ACRTextField: NSTextField {
     
     private func updateClearButton() {
         clearButton.isHidden = isEmpty
+        clearButton.isHidden ? errorMessageHandler?.hideErrorMessage(for: self) : errorMessageHandler?.showErrorMessage(for: self)
     }
     
     private var wantsClearButton: Bool {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -14,7 +14,7 @@ class ACRView: ACRColumnView {
     private (set) var renderedShowCards: [NSView] = []
     private (set) var initialLayoutDone = false
     private var currentFocusedActionElement: NSCell?
-    private var isLayoutDoneOnShowCard: Bool = false
+    private var isLayoutDoneOnShowCard = false
     
     init(style: ACSContainerStyle, hostConfig: ACSHostConfig, renderConfig: RenderConfig) {
         self.renderConfig = renderConfig

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeChoiceSetInput.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeChoiceSetInput.swift
@@ -8,6 +8,11 @@ class FakeChoiceSetInput: ACSChoiceSetInput {
     public var value: String?
     public var wrap: Bool = false
     public var id: String? = ""
+    public var visibility: Bool = true
+    public var isRequired: Bool = false
+    public var errorMessage: String?
+    public var label: String?
+    public var separator: Bool = false
     
     open override func getIsMultiSelect() -> Bool {
         return isMultiSelect
@@ -56,9 +61,49 @@ class FakeChoiceSetInput: ACSChoiceSetInput {
     override func getId() -> String? {
         return id
     }
+    
+    override func getIsVisible() -> Bool {
+        return visibility
+    }
+    
+    override func setIsVisible(_ value: Bool) {
+        visibility = value
+    }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+    
+    override func getLabel() -> String? {
+        return label
+    }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func setSeparator(_ value: Bool) {
+        separator = value
+    }
 }
 extension FakeChoiceSetInput {
-    static func make(isMultiSelect: Bool = false, value: String = "1", choices: [ACSChoiceInput] = [], wrap: Bool = false, choiceSetStyle: ACSChoiceSetStyle = .expanded, placeholder: String? = "") -> FakeChoiceSetInput {
+    static func make(isMultiSelect: Bool = false, value: String = "1", choices: [ACSChoiceInput] = [], wrap: Bool = false, choiceSetStyle: ACSChoiceSetStyle = .expanded, placeholder: String? = "", visibility: Bool = false, isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false) -> FakeChoiceSetInput {
         let fakeChoiceSetInput = FakeChoiceSetInput()
         fakeChoiceSetInput.placeholder = placeholder
         fakeChoiceSetInput.value = value
@@ -66,6 +111,11 @@ extension FakeChoiceSetInput {
         fakeChoiceSetInput.choices = choices
         fakeChoiceSetInput.isMultiSelect = isMultiSelect
         fakeChoiceSetInput.wrap = wrap
+        fakeChoiceSetInput.visibility = visibility
+        fakeChoiceSetInput.isRequired = isRequired
+        fakeChoiceSetInput.errorMessage = errorMessage
+        fakeChoiceSetInput.label = label
+        fakeChoiceSetInput.separator = separator
         return fakeChoiceSetInput
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
@@ -7,6 +7,10 @@ class FakeInputDate: ACSDateInput {
     public var min: String?
     public var id: String? = ""
     public var visibility: Bool = true
+    public var isRequired: Bool = false
+    public var errorMessage: String?
+    public var label: String?
+    public var separator: Bool = false
 
     open override func getValue() -> String? {
         return value
@@ -47,15 +51,51 @@ class FakeInputDate: ACSDateInput {
     override func getIsVisible() -> Bool {
         return visibility
     }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+    
+    override func getLabel() -> String? {
+        return label
+    }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func setSeparator(_ value: Bool) {
+        separator = value
+    }
 }
 
 extension FakeInputDate {
-    static func make(value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "") -> FakeInputDate {
+    static func make(value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "", isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false) -> FakeInputDate {
         let fakeInputDate = FakeInputDate()
         fakeInputDate.value = value
         fakeInputDate.placeholder = placeholder
         fakeInputDate.max = max
         fakeInputDate.min = min
+        fakeInputDate.isRequired = isRequired
+        fakeInputDate.errorMessage = errorMessage
+        fakeInputDate.label = label
+        fakeInputDate.separator = separator
         return fakeInputDate
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputNumber.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputNumber.swift
@@ -10,6 +10,8 @@ class FakeInputNumber: ACSNumberInput {
     public var separator: Bool = false
     public var spacing: ACSSpacing = .default
     public var label: String? = ""
+    public var isRequired: Bool = false
+    public var errorMessage: String?
 
     open override func getValue() -> NSNumber? {
         return value
@@ -70,10 +72,30 @@ class FakeInputNumber: ACSNumberInput {
     override func getLabel() -> String? {
         return label
     }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
 }
 
 extension FakeInputNumber {
-    static func make(value: NSNumber? = 0, placeholder: String? = "", max: NSNumber? = .init(value: Double.greatestFiniteMagnitude), min: NSNumber? = .init(value: -Double.greatestFiniteMagnitude), visible: Bool? = true, separator: Bool = false, spacing: ACSSpacing = .default, label: String? = nil) -> FakeInputNumber {
+    static func make(value: NSNumber? = 0, placeholder: String? = "", max: NSNumber? = 0, min: NSNumber = 0, visible: Bool? = true, separator: Bool = false, spacing: ACSSpacing = .default, label: String? = nil, isRequired: Bool = false, errorMessage: String? = "") -> FakeInputNumber {
         let fakeInputNumber = FakeInputNumber()
         fakeInputNumber.value = value
         fakeInputNumber.placeholder = placeholder
@@ -83,6 +105,8 @@ extension FakeInputNumber {
         fakeInputNumber.separator = separator
         fakeInputNumber.spacing = spacing
         fakeInputNumber.label = label
+        fakeInputNumber.isRequired = isRequired
+        fakeInputNumber.errorMessage = errorMessage
         return fakeInputNumber
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputTime.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputTime.swift
@@ -7,6 +7,10 @@ class FakeInputTime: ACSTimeInput {
     public var min: String?
     public var id: String? = ""
     public var visibility: Bool = true
+    public var isRequired: Bool = false
+    public var errorMessage: String?
+    public var label: String?
+    public var separator: Bool = false
 
     open override func getValue() -> String? {
         return value
@@ -47,15 +51,51 @@ class FakeInputTime: ACSTimeInput {
     override func getIsVisible() -> Bool {
         return visibility
     }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+    
+    override func getLabel() -> String? {
+        return label
+    }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func setSeparator(_ value: Bool) {
+        separator = value
+    }
 }
 
 extension FakeInputTime {
-    static func make(value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "") -> FakeInputTime {
+    static func make(value: String? = "", placeholder: String? = "", max: String? = "", min: String? = "", isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false) -> FakeInputTime {
         let fakeInputTime = FakeInputTime()
         fakeInputTime.value = value
         fakeInputTime.placeholder = placeholder
         fakeInputTime.max = max
         fakeInputTime.min = min
+        fakeInputTime.isRequired = isRequired
+        fakeInputTime.errorMessage = errorMessage
+        fakeInputTime.label = label
+        fakeInputTime.separator = separator
         return fakeInputTime
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputToggle.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputToggle.swift
@@ -9,6 +9,9 @@ class FakeInputToggle: ACSToggleInput {
     public var id: String? = ""
     public var label: String? = ""
     public var visibility: Bool = true
+    public var isRequired: Bool = false
+    public var errorMessage: String?
+    public var separator: Bool = false
     
     open override func getTitle() -> String? {
         return title
@@ -69,15 +72,38 @@ class FakeInputToggle: ACSToggleInput {
     override func getLabel() -> String? {
         return label
     }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
 }
 extension FakeInputToggle {
-    static func make(title: String? = "", value: String = "false", valueOn: String = "true", valueOff: String = "false", wrap: Bool = false) ->FakeInputToggle {
+    static func make(title: String? = "", value: String = "false", valueOn: String = "true", valueOff: String = "false", wrap: Bool = false, isRequired: Bool = false, errorMessage: String? = "", label: String? = "") ->FakeInputToggle {
         let fakeInputToggle = FakeInputToggle()
         fakeInputToggle.title = title
         fakeInputToggle.value = value
         fakeInputToggle.valueOn = valueOn
         fakeInputToggle.valueOff = valueOff
         fakeInputToggle.wrap = wrap
+        fakeInputToggle.isRequired = isRequired
+        fakeInputToggle.errorMessage = errorMessage
+        fakeInputToggle.label = label
         return fakeInputToggle
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextInput.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeTextInput.swift
@@ -10,6 +10,10 @@ class FakeInputText: ACSTextInput {
     public var regexString: String?
     public var id: String? = ""
     public var visibility: Bool = true
+    public var isRequired: Bool = false
+    public var errorMessage: String?
+    public var label: String?
+    public var separator: Bool = false
     
     override func getPlaceholder() -> String? {
         return placeholderString
@@ -74,10 +78,42 @@ class FakeInputText: ACSTextInput {
     override func getIsVisible() -> Bool {
         return visibility
     }
+    
+    override func getIsRequired() -> Bool {
+        return isRequired
+    }
+    
+    override func setIsRequired(_ isRequired: Bool) {
+        self.isRequired = isRequired
+    }
+    
+    override func getErrorMessage() -> String? {
+        return errorMessage
+    }
+    
+    override func setErrorMessage(_ errorMessage: String) {
+        self.errorMessage = errorMessage
+    }
+    
+    override func getLabel() -> String? {
+        return label
+    }
+    
+    override func setLabel(_ label: String) {
+        self.label = label
+    }
+    
+    override func getSeparator() -> Bool {
+        return separator
+    }
+    
+    override func setSeparator(_ value: Bool) {
+        separator = value
+    }
 }
 
 extension FakeInputText {
-    static func make(placeholderString: String? = "", value: String? = "", isMultiline: Bool = false, maxLength: NSNumber? = 0, style: ACSTextInputStyle = .text, inlineAction: ACSBaseActionElement? = .none, regexString: String? = "") -> FakeInputText {
+    static func make(placeholderString: String? = "", value: String? = "", isMultiline: Bool = false, maxLength: NSNumber? = 0, style: ACSTextInputStyle = .text, inlineAction: ACSBaseActionElement? = .none, regexString: String? = "", isRequired: Bool = false, errorMessage: String? = "", label: String? = "", separator: Bool = false) -> FakeInputText {
         let fakeInputText = FakeInputText()
         fakeInputText.placeholderString = placeholderString
         fakeInputText.value = value
@@ -86,6 +122,10 @@ extension FakeInputText {
         fakeInputText.style = style
         fakeInputText.inlineAction = inlineAction
         fakeInputText.regexString = regexString
+        fakeInputText.isRequired = isRequired
+        fakeInputText.errorMessage = errorMessage
+        fakeInputText.label = label
+        fakeInputText.separator = separator
         return fakeInputText
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -50,6 +50,125 @@ class BaseCardElementRendererrTests: XCTestCase {
         XCTAssertEqual(viewWithInheritedProperties.identifier?.rawValue, "helloworld")
     }
     
+    func testInputTextErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputText = FakeInputText.make(isRequired: true, errorMessage: "Error")
+        let view = TextInputRenderer().render(element: inputText, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRTextInputView)
+        guard let inputTextView = view as? ACRTextInputView else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputText, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputTextView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputTextView.errorMessageHandler?.hideErrorMessage(for: inputTextView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
+    
+    func testInputNumberErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputNumber = FakeInputNumber.make(isRequired: true, errorMessage: "Error")
+        let view = InputNumberRenderer().render(element: inputNumber, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRNumericTextField)
+        guard let inputNumberView = view as? ACRNumericTextField else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputNumber, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputNumberView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputNumberView.errorMessageHandler?.hideErrorMessage(for: inputNumberView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
+    
+    func testInputDateErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputDate = FakeInputDate.make(isRequired: true, errorMessage: "Error")
+        let view = InputDateRenderer().render(element: inputDate, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRDateField)
+        guard let inputDateView = view as? ACRDateField else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputDate, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputDateView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputDateView.errorMessageHandler?.hideErrorMessage(for: inputDateView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
+    
+    func testInputTimeErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputTime = FakeInputTime.make(isRequired: true, errorMessage: "Error")
+        let view = InputTimeRenderer().render(element: inputTime, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRDateField)
+        guard let inputTimeView = view as? ACRDateField else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputTime, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputTimeView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputTimeView.errorMessageHandler?.hideErrorMessage(for: inputTimeView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
+    
+    func testInputChoiceSetErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputChoiceSet = FakeChoiceSetInput.make(isRequired: true, errorMessage: "Error")
+        let view = ChoiceSetInputRenderer().render(element: inputChoiceSet, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRChoiceSetView)
+        guard let inputChoiceSetView = view as? ACRChoiceSetView else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputChoiceSet, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputChoiceSetView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputChoiceSetView.errorMessageHandler?.hideErrorMessage(for: inputChoiceSetView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
+    
+    func testInputToggleErrorMessageHandler() {
+        let config = RenderConfig(isDarkMode: false, buttonConfig: .default, supportsSchemeV1_3: true, hyperlinkColorConfig: .default, inputFieldConfig: .default, checkBoxButtonConfig: nil, radioButtonConfig: nil, localisedStringConfig: nil)
+        let fakeErrorMessageHandlerDelegate = FakeErrorMessageHandlerDelegate()
+        
+        let inputToggle = FakeInputToggle.make(isRequired: true, errorMessage: "Error")
+        let view = InputToggleRenderer().render(element: inputToggle, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: config)
+        XCTAssertTrue(view is ACRChoiceButton)
+        guard let inputToggleView = view as? ACRChoiceButton else { fatalError() }
+        
+        let viewWithInheritedProperties = baseCardRenderer.updateView(view: view, element: inputToggle, rootView: FakeRootView(), style: .default, hostConfig: hostConfig, config: config, isfirstElement: true)
+        XCTAssertTrue(viewWithInheritedProperties is ACRContentStackView)
+        guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
+        
+        inputToggleView.errorMessageHandler = fakeErrorMessageHandlerDelegate
+        XCTAssertEqual(updatedView.errorMessageView?.stringValue, "Error")
+        XCTAssertFalse(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+        inputToggleView.errorMessageHandler?.hideErrorMessage(for: inputToggleView)
+        XCTAssertTrue(fakeErrorMessageHandlerDelegate.isErrorMessageHidden)
+    }
     
     private func renderBaseCardElementView() -> ACRContentStackView {
         let view = containerRenderer.render(element: container, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
@@ -60,5 +179,16 @@ class BaseCardElementRendererrTests: XCTestCase {
         
         guard let updatedView = viewWithInheritedProperties as? ACRContentStackView else { fatalError() }
         return updatedView
+    }
+}
+
+private class FakeErrorMessageHandlerDelegate: ErrorMessageHandlerDelegate{
+    var isErrorMessageHidden: Bool = false
+    func showErrorMessage(for view: NSView) {
+        isErrorMessageHidden = false
+    }
+    
+    func hideErrorMessage(for view: NSView) {
+        isErrorMessageHidden = true
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/BaseCardElementRendererTests.swift
@@ -184,11 +184,11 @@ class BaseCardElementRendererrTests: XCTestCase {
 
 private class FakeErrorMessageHandlerDelegate: ErrorMessageHandlerDelegate{
     var isErrorMessageHidden: Bool = false
-    func showErrorMessage(for view: NSView) {
+    func showErrorMessage(for view: InputHandlingViewProtocol) {
         isErrorMessageHidden = false
     }
     
-    func hideErrorMessage(for view: NSView) {
+    func hideErrorMessage(for view: InputHandlingViewProtocol) {
         isErrorMessageHidden = true
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Views/ACRViewTests.swift
@@ -309,6 +309,7 @@ private class FakeInputHandlingView: NSView, InputHandlingViewProtocol {
     var value: String = NSUUID().uuidString
     var key: String = NSUUID().uuidString
     var isValid: Bool = true
+    var errorMessageHandler: ErrorMessageHandlerDelegate?
 }
 
 private class FakeImageHoldingView: NSView, ImageHoldingView {


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

Create a simple way for Cards to show and hide error message by adding delegates to baseCardenderer

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

No UI change as of yet

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***


Unit tests added