### PR TITLE
[Win] Text Select Added to Adaptive Cards

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -83,6 +83,9 @@ namespace RendererQml
 		uiCard->Property("readonly property int margins", std::to_string(margin));
         uiCard->AddFunctions("signal buttonClicked(var title, var type, var data)");
         uiCard->AddFunctions("signal sendCardHeight(var cardHeight)");
+        uiCard->AddFunctions("signal openContextMenu(var globalPos, string selectedText, string link)");
+        uiCard->AddFunctions("signal textEditFocussed(var textEdit)");
+        uiCard->AddFunctions("signal setFocusBackOnClose(var element)");
 		//1px extra height to accomodate the border of a showCard if present at the bottom
         uiCard->Property("implicitHeight", "adaptiveCardLayout.implicitHeight");
 		uiCard->Property("Layout.fillWidth", "true");
@@ -480,7 +483,10 @@ namespace RendererQml
         uiColumn->AddFunctions(Formatter() << "function reload(mCard)\n{\n");
         uiColumn->AddFunctions(Formatter() << "if (card)\n{ \ncard.destroy()\n }\n");
         uiColumn->AddFunctions(Formatter() << "card = Qt.createQmlObject(mCard, " << layoutId << ", 'card')\n");
-        uiColumn->AddFunctions(Formatter() << "if (card)\n{ \ncard.buttonClicked.connect(adaptiveCard.buttonClicked)\n }\n}");
+        uiColumn->AddFunctions(Formatter() << "if (card)\n{ \ncard.buttonClicked.connect(adaptiveCard.buttonClicked);"
+            "card.openContextMenu.connect(adaptiveCard.openContextMenu);"
+            "card.textEditFocussed.connect(adaptiveCard.textEditFocussed);"
+            "card.setFocusBackOnClose.connect(adaptiveCard.setFocusBackOnClose)}}");
 
 		uiComponent->AddChild(uiColumn);
 
@@ -520,6 +526,13 @@ namespace RendererQml
             textBlock->SetId(context->ConvertToValidId(textBlock->GetId()));
 			uiTextBlock->Property("id", textBlock->GetId());
 		}
+        else
+        {
+        textBlock->SetId(Formatter() << "text_block" << context->getTextBlockCounter());
+        }
+
+        uiTextBlock->Property("id", textBlock->GetId());
+
 
 		if (!textBlock->GetIsVisible())
 		{
@@ -551,7 +564,7 @@ namespace RendererQml
 		uiTextBlock->Property("text", text, true);
 
 		//MouseArea to Change Cursor on Hovering Links
-		auto MouseAreaTag = GetTextBlockMouseArea();
+        auto MouseAreaTag = GetTextBlockMouseArea(uiTextBlock->GetId());
 		uiTextBlock->AddChild(MouseAreaTag);
 
 		std::string onLinkActivatedFunction = Formatter() << "{"
@@ -589,6 +602,12 @@ namespace RendererQml
 			richTextBlock->SetId(context->ConvertToValidId(richTextBlock->GetId()));
 			uiTextBlock->Property("id", richTextBlock->GetId());
 		}
+        else
+        {
+            richTextBlock->SetId(Formatter() << "rich_text_block" << context->getTextBlockCounter());
+        }
+
+        uiTextBlock->Property("id", richTextBlock->GetId());
 
 		uiTextBlock->Property("textFormat", "Text.RichText");
 		uiTextBlock->Property("wrapMode", "Text.Wrap");
@@ -623,7 +642,7 @@ namespace RendererQml
 		uiTextBlock->Property("text", textrun_all, true);
 
 		//MouseArea to Change Cursor on Hovering Links
-		auto MouseAreaTag = GetTextBlockMouseArea();
+		auto MouseAreaTag = GetTextBlockMouseArea(uiTextBlock->GetId());
 		uiTextBlock->AddChild(MouseAreaTag);
 
         context->addToTextRunSelectActionList(uiTextBlock, selectActionList);
@@ -2489,12 +2508,35 @@ namespace RendererQml
         return iconTag;
     }
 
-	std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::GetTextBlockMouseArea()
+	std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::GetTextBlockMouseArea(std::string textBlockId)
 	{
 		auto MouseAreaTag = std::make_shared<QmlTag>("MouseArea");
 		MouseAreaTag->Property("anchors.fill", "parent");
-		MouseAreaTag->Property("cursorShape", "parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor");
-		MouseAreaTag->Property("acceptedButtons", "Qt.NoButton");
+        MouseAreaTag->Property("hoverEnabled", "true");
+        MouseAreaTag->Property("preventStealing", "true");
+        MouseAreaTag->Property("id", Formatter() << textBlockId << "_mouseArea");
+        MouseAreaTag->Property("cursorShape", "parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor;");
+        MouseAreaTag->Property("acceptedButtons", "Qt.RightButton | Qt.LeftButton");
+
+        std::string onPressed = Formatter() << "onPressed : {"
+            << "mouse.accepted = false;"
+            << "const mouseGlobal = mapToGlobal(mouseX, mouseY);"
+            << "const posAtMessage = mapToItem(adaptiveCard, mouse.x, mouse.y);"
+            << "if (mouse.button === Qt.RightButton){"
+            << "openContextMenu(mouseGlobal, " << textBlockId << ".selectedText, parent.linkAt(mouse.x, mouse.y));mouse.accepted = true;}"
+            << "else if (mouse.button === Qt.LeftButton){"
+            << "parent.cursorPosition = parent.positionAt(posAtMessage.x, posAtMessage.y);"
+            << "parent.forceActiveFocus();}}";
+
+        std::string onPositionChanged = Formatter() << "onPositionChanged : {"
+            << "if (mouse.buttons & Qt.LeftButton)parent.moveCursorSelection(parent.positionAt(mouse.x, mouse.y));"
+            << "var link = parent.linkAt(mouse.x, mouse.y);"
+            << "if (link){cursorShape = Qt.PointingHandCursor;}"
+            << "else{cursorShape = Qt.IBeamCursor;}"
+            << "mouse.accepted = true;}";
+
+        MouseAreaTag->AddFunctions(onPressed);
+        MouseAreaTag->AddFunctions(onPositionChanged);
 
 		return MouseAreaTag;
 	}
@@ -2639,8 +2681,10 @@ namespace RendererQml
         uiTextBlock->Property("activeFocusOnTab", "true");
         uiTextBlock->Property("Accessible.name", "accessibleText");
         uiTextBlock->Property("readOnly", "true");
-        uiTextBlock->Property("selectByMouse", "false");
-        uiTextBlock->Property("selectByKeyboard", "false");
+        uiTextBlock->Property("selectByMouse", "true");
+        uiTextBlock->Property("selectByKeyboard", "true");
+        uiTextBlock->Property("selectionColor ", Formatter() << context->GetHexColor(cardConfig.textHighlightBackground));
+        uiTextBlock->Property("selectedTextColor ", "color");
         uiTextBlock->Property("Keys.onPressed", Formatter() << "{"
             << "if (event.key === Qt.Key_Tab) {event.accepted = selectLink(this, true);}"
             << "else if (event.key === Qt.Key_Backtab) {event.accepted = selectLink(this, false);}"
@@ -2651,7 +2695,15 @@ namespace RendererQml
             << "else {accessibleText = ''}}");
 
         uiTextBlock->Property("onActiveFocusChanged", Formatter() << "{"
-            << "if (activeFocus) { accessibleText = getText(0,length);}}");
+            << "if (activeFocus) { textEditFocussed(" << uiTextBlock->GetId() << "); accessibleText = getText(0,length);}}");
+
+        uiTextBlock->AddFunctions("function getSelectedRichText() {return activeFocus ? selectedText : \"\";}");
+
+        uiTextBlock->AddFunctions(Formatter() << "function getExternalLinkUnderCursor() {if(!activeFocus) return \"\";"
+            << "const possibleLinkPosition = selectionEnd > cursorPosition ? cursorPosition + 1 : cursorPosition;"
+            << "let rectangle = positionToRectangle(possibleLinkPosition);"
+            << "let correctedX = (rectangle.x > 0 ? rectangle.x - 1 : 0);"
+            << "return linkAt(correctedX, rectangle.y);}");
 
         auto uiFocusRectangle = std::make_shared<QmlTag>("Rectangle");
         uiFocusRectangle->Property("anchors.fill", "parent");

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -112,7 +112,7 @@ namespace RendererQml
 		static const std::shared_ptr<QmlTag> applyVerticalBleed(std::shared_ptr<QmlTag> elementsParent, std::shared_ptr<QmlTag> source);
 		static const std::shared_ptr<QmlTag> addColumnSetElements(std::shared_ptr<AdaptiveCards::ColumnSet> columnSet, std::shared_ptr<QmlTag> uiFrame, std::shared_ptr<AdaptiveRenderContext> context);
 
-        static std::shared_ptr<QmlTag> GetTextBlockMouseArea();
+        static std::shared_ptr<QmlTag> GetTextBlockMouseArea(std::string textBlockId);
         static std::shared_ptr<QmlTag> getDummyElementforNumberInput(bool isTop);
 
         static void ValidateLastBodyElementIsShowCard(const std::vector<std::shared_ptr<AdaptiveCards::BaseCardElement>>& bodyElements, std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
@@ -9,6 +9,7 @@ namespace RendererQml
     {
         std::string cardBorderColor{ "#33FFFFFF" };
         std::string focusRectangleColor{ "#80FFFFFF" };
+        std::string textHighlightBackground{ "#FF092D3B" };
         int cardRadius{ 8 };
     };
 

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -241,6 +241,11 @@ namespace RendererQml
         return ++m_FactSetCounter;
     }
 
+    const int AdaptiveRenderContext::getTextBlockCounter()
+    {
+        return ++m_TextBlockCounter;
+    }
+
     const int RendererQml::AdaptiveRenderContext::getContentIndex()
     {
         return m_ContentIndex;

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -45,6 +45,7 @@ namespace RendererQml
         const int getButtonCounter();
         const int getSelectActionCounter();
         const int getFactSetCounter();
+        const int getTextBlockCounter();
 
         const int getContentIndex();
         void setContentIndex(int contentCounter);
@@ -136,6 +137,7 @@ namespace RendererQml
         int m_DefaultIdCounter{ 0 };
         int m_ActionSetCounter{ 0 };
         int m_FactSetCounter{ 0 };
+        int m_TextBlockCounter{ 0 };
         int m_ContentIndex{ 0 };
 
     };

--- a/source/qml/Library/RendererQml/ComboBoxRender.cpp
+++ b/source/qml/Library/RendererQml/ComboBoxRender.cpp
@@ -24,8 +24,6 @@ void ComboBoxElement::initialize()
     mComboBox->Property("valueRole", "'value'");
     mComboBox->Property("width", "parent.width");
     mComboBox->Property("height", RendererQml::Formatter() << mChoiceSetConfig.height);
-    mComboBox->Property("Keys.onReturnPressed", RendererQml::Formatter() << mChoiceSet.id << ".popup.open()");
-    mComboBox->Property("onAccepted", RendererQml::Formatter() << mChoiceSet.id << ".popup.close()");
 
     mComboBox->Property("model", getModel(mChoiceSet.choices));
     mComboBox->Property("indicator", getArrowIcon()->ToString());
@@ -167,9 +165,7 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getPopup()
     popupTag->Property("y", RendererQml::Formatter() << mChoiceSet.id << ".height + 5");
     popupTag->Property("width", RendererQml::Formatter() << mChoiceSet.id << ".width");
     popupTag->Property("padding", RendererQml::Formatter() << mChoiceSetConfig.dropDownPadding);
-    popupTag->Property("height", RendererQml::Formatter() << contentListViewId << ".contentHeight + (2 * " << mChoiceSetConfig.dropDownPadding << ")" << " > " << mChoiceSetConfig.dropDownHeight << " ? " << mChoiceSetConfig.dropDownHeight << " :" << contentListViewId << ".contentHeight + ( 2 * " << mChoiceSetConfig.dropDownPadding << ")"); // Get from config
-    popupTag->Property("onOpened", RendererQml::Formatter() << contentListViewId << ".forceActiveFocus()");
-    popupTag->Property("onClosed", RendererQml::Formatter() << mChoiceSet.id << ".forceActiveFocus()");
+    popupTag->Property("height", RendererQml::Formatter() << contentListViewId << ".contentHeight + (2 * " << mChoiceSetConfig.dropDownPadding << ")" << " > " << mChoiceSetConfig.dropDownHeight << " ? " << mChoiceSetConfig.dropDownHeight << " :" << contentListViewId << ".contentHeight + ( 2 * " << mChoiceSetConfig.dropDownPadding << ")");
 
     popupTag->Property("background", popupBackgroundTag->ToString());
     popupTag->Property("contentItem", contentListViewTag->ToString());

--- a/source/qml/Library/RendererQml/DateInputRender.cpp
+++ b/source/qml/Library/RendererQml/DateInputRender.cpp
@@ -227,7 +227,7 @@ void DateInputElement::initDateInputComboBox()
     mDateInputCombobox->Property("popup", mDateInputCalendar->ToString());
     mDateInputCombobox->Property("indicator", "Rectangle{}");
     mDateInputCombobox->Property("focusPolicy", "Qt.NoFocus");
-    mDateInputCombobox->Property("Keys.onReturnPressed", "this.popup.open()");
+    mDateInputCombobox->Property("Keys.onReturnPressed", RendererQml::Formatter() << "{setFocusBackOnClose(" << mDateInputComboboxId << ");this.popup.open();}");
 
     mDateInputTextField->Property("onPressed", RendererQml::Formatter() << mDateInputWrapperId << ".colorChange(true)");
     mDateInputTextField->Property("onReleased", RendererQml::Formatter() << mDateInputWrapperId << ".colorChange(false)");

--- a/source/qml/Library/RendererQml/TimeInputRender.cpp
+++ b/source/qml/Library/RendererQml/TimeInputRender.cpp
@@ -155,7 +155,7 @@ void TimeInputElement::initTimeInputComboBox()
     mTimeInputComboBox->Property("id", RendererQml::Formatter() << id << "_combobox");
 
     mTimeInputComboBox->Property("Layout.fillWidth", "true");
-    mTimeInputComboBox->Property("Keys.onReturnPressed", RendererQml::Formatter() << timePopupId << ".open()");
+    mTimeInputComboBox->Property("Keys.onReturnPressed", RendererQml::Formatter() << "{setFocusBackOnClose(" << mTimeInputComboBox->GetId() << ");" << timePopupId << ".open();}");
     mTimeInputComboBox->Property("focusPolicy", "Qt.NoFocus");
     mTimeInputComboBox->Property("onActiveFocusChanged", RendererQml::Formatter() << mTimeInputWrapper->GetId() << ".colorChange(false)");
     mTimeInputComboBox->Property("Accessible.ignored", "true");

--- a/source/qml/Samples/QmlVisualizer/AdaptiveCardItemDelegate.qml
+++ b/source/qml/Samples/QmlVisualizer/AdaptiveCardItemDelegate.qml
@@ -9,6 +9,7 @@ Item {
 
     signal reloadCard(var card)
     signal adaptiveCardButtonClicked(var title, var type, var data)
+    signal openContextMenu(var pos, var text, var link)
 
     height: mainLayout.height
     width: listView.width
@@ -42,6 +43,7 @@ Item {
                     onLoaded: {
                         reloadCard.connect(item.reload)
                         item.adaptiveCardButtonClicked.connect(adaptiveCardButtonClicked)
+                        item.openContextMenu.connect(openContextMenu)
                     }
                 }
             }

--- a/source/qml/Samples/QmlVisualizer/CardComponent.qml
+++ b/source/qml/Samples/QmlVisualizer/CardComponent.qml
@@ -6,6 +6,7 @@ ColumnLayout{
 
     property var card
     signal adaptiveCardButtonClicked(var title, var type, var data)
+    signal openContextMenu(var pos, var text, var link)
 
     Component.onCompleted: reload(CardString);
 
@@ -17,5 +18,6 @@ ColumnLayout{
 
         card = Qt.createQmlObject(mCard, cardComponent, "card")
         card.buttonClicked.connect(adaptiveCardButtonClicked)
+        card.openContextMenu.connect(openContextMenu)
     }
 }

--- a/source/qml/Samples/QmlVisualizer/QmlVisualizer.vcxproj
+++ b/source/qml/Samples/QmlVisualizer/QmlVisualizer.vcxproj
@@ -77,7 +77,7 @@
   </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" Label="QtSettings">
     <QtInstall>qt64</QtInstall>
-    <QtModules>quick</QtModules>
+    <QtModules>widgets;quick</QtModules>
     <QtBuildConfig>debug</QtBuildConfig>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" Label="QtSettings">

--- a/source/qml/Samples/QmlVisualizer/main.cpp
+++ b/source/qml/Samples/QmlVisualizer/main.cpp
@@ -3,7 +3,7 @@
 #include "samplecardlist.h"
 #include "SampleCardJson.h"
 
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQuickView>
 #include <QQmlContext>
 #include <QQmlEngine>
@@ -11,7 +11,7 @@
 
 int main(int argc, char* argv[])
 {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     qmlRegisterType<SampleCardModel>("SampleCard", 1, 0, "SampleCardModel");
     qmlRegisterUncreatableType<SampleCardList>("SampleCard", 1, 0, "SampleCardList",

--- a/source/qml/Samples/QmlVisualizer/main.qml
+++ b/source/qml/Samples/QmlVisualizer/main.qml
@@ -58,6 +58,7 @@ Row{
                         cardEditorLoader.item.reloadCard.connect(loader.item.reloadCard)
                         cardListViewLoader.item.reloadCard.connect(loader.item.reloadCard)
                         loader.item.adaptiveCardButtonClicked.connect(root.onAdaptiveCardButtonClicked)
+                        loader.item.openContextMenu.connect(root.onOpenContextMenu);
                     }
                 }
             }
@@ -93,5 +94,9 @@ Row{
     function onAdaptiveCardButtonClicked(title, type, data){
         _aModel.onAdaptiveCardButtonClicked(title, type, data)
         cardOutputLoader.item.open()
+    }
+
+    function onOpenContextMenu(pos, text, link){
+        _aModel.onOpenContextMenu(pos, text, link)
     }
 }

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -21,6 +21,7 @@ SampleCardModel::SampleCardModel(QObject *parent)
     std::shared_ptr<AdaptiveSharedNamespace::HostConfig> hostConfig = std::make_shared<AdaptiveSharedNamespace::HostConfig>(AdaptiveSharedNamespace::HostConfig::DeserializeFromString(LightConfig::lightConfig));
     auto renderConfig = getRenderConfig(false);
     renderer_ptr = std::make_shared<AdaptiveCardQmlRenderer>(AdaptiveCardQmlRenderer(hostConfig, renderConfig));
+    mContextMenu = new QMenu();
 }
 
 int SampleCardModel::rowCount(const QModelIndex &parent) const
@@ -223,6 +224,23 @@ void SampleCardModel::onAdaptiveCardButtonClicked(const QString& title, const QS
     {
         actionSubmitButtonClicked(title, type, data);
     }
+}
+
+void SampleCardModel::onOpenContextMenu(const QPoint& pos, const QString& selectedText, const QString& link)
+{
+    mContextMenu->clear();
+
+    if (!link.isEmpty())
+    {
+        mContextMenu->addAction(QString::fromStdString("Copy link"), [link, this]() { QApplication::clipboard()->setText(link); });
+    }
+
+    if (!selectedText.isEmpty())
+    {
+        mContextMenu->addAction(QString::fromStdString("Copy text"), [selectedText, this]() { QApplication::clipboard()->setText(selectedText); });
+    }
+
+    mContextMenu->popup(pos);
 }
 
 void SampleCardModel::actionOpenUrlButtonClicked(const QString& title, const QString& type, const QString& data)

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -420,6 +420,7 @@ CardConfig SampleCardModel::getCardConfig(const bool isDark)
     {
         cardConfig.cardBorderColor = "#33000000";
         cardConfig.focusRectangleColor = "#80000000";
+        cardConfig.textHighlightBackground = "#FFC7F6FF";
     }
     return cardConfig;
 }

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.h
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.h
@@ -7,6 +7,9 @@
 #include "Utils.h"
 
 #include <QAbstractListModel>
+#include <QApplication>
+#include <QClipboard>
+#include <QMenu>
 
 using namespace RendererQml;
 
@@ -40,6 +43,7 @@ public:
     Q_INVOKABLE QString generateQml(const QString& cardQml);
     Q_INVOKABLE void setTheme(const QString& theme);
     Q_INVOKABLE void onAdaptiveCardButtonClicked(const QString& title, const QString& type, const QString& data);
+    Q_INVOKABLE void onOpenContextMenu(const QPoint& pos, const QString& selectedText, const QString& link);
 
 signals:
     void reloadCardOnThemeChange();
@@ -59,6 +63,7 @@ private:
     static std::pair<std::map<int, std::string>, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>>> GetCardImageUrls(std::shared_ptr<AdaptiveCards::BaseCardElement> cardElement, std::map<int, std::string> urls, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>> showCards);
     static std::pair<std::map<int, std::string>, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>>> GetActionImageUrls(std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> cardElement, std::map<int, std::string> urls, std::vector<std::shared_ptr<AdaptiveCards::AdaptiveCard>> showCards);
 
+    QMenu* mContextMenu{ nullptr };
     std::shared_ptr<AdaptiveCardRenderConfig> getRenderConfig(const bool isDark);
     CardConfig getCardConfig(const bool isDark);
     template<typename InputConfig>


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description

- Selecting a single text block enabled for Adaptive Cards

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

![Dark Text Select](https://user-images.githubusercontent.com/78958353/161926869-c8af3dae-7119-4372-aa9c-690db743adf8.jpg)
![Light Text Select](https://user-images.githubusercontent.com/78958353/161926879-fadeb3f1-44ec-4dd1-b390-a01d31b1fa91.jpg)
![image](https://user-images.githubusercontent.com/78958353/167416677-a94af98c-70fc-40b3-bfd3-46eb004441a2.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
