### PR TITLE
[Win] Buttons and Cards Center Alignment in Action Set 

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -327,10 +327,29 @@ namespace RendererQml
             AddSeparator(uiContainer, std::make_shared<AdaptiveCards::Container>(), context);
             uiContainer->AddChild(uiButtonStrip);
 
+            std::ostringstream rectangleElements;
+            std::ostringstream actionElements;
+            std::shared_ptr<QmlTag> uiRectangle;
+
             for (unsigned int i = 0; i < maxActions; i++)
             {
                 // add actions buttons
                 auto uiAction = context->Render(actions[i]);
+                if (actionsConfig.actionAlignment == AdaptiveCards::ActionAlignment::Center)
+                {
+                    uiRectangle = std::make_shared<RendererQml::QmlTag>("Rectangle");
+                    uiRectangle->Property("id", Formatter() << uiAction->GetId() << "_rectangle");
+                    uiRectangle->Property("height", Formatter() << uiAction->GetId() << ".height");
+                    uiRectangle->Property("width", Formatter() << uiAction->GetId() << ".width");
+                    //uiRectangle->Property("Component.onCompleted", "horizontalAlign()");
+
+                    uiAction->Property("width", "(parent.parent.width > implicitWidth) ? implicitWidth : parent.parent.width");
+
+                    rectangleElements << (i == 0 ? "[" : "") << uiRectangle->GetId() << (i == maxActions - 1 ? "]" : ",");
+                    actionElements << (i == 0 ? "[" : "") << uiAction->GetId() << (i == maxActions - 1 ? "]" : ",");
+                    uiRectangle->AddChild(uiAction);
+                }
+
                 if (uiAction != nullptr)
                 {
                     if (Utils::IsInstanceOfSmart<AdaptiveCards::ShowCardAction>(actions[i]))
@@ -363,8 +382,18 @@ namespace RendererQml
                         uiContainer->AddChild(uiLoader);
                     }
 
-                    uiButtonStrip->AddChild(uiAction);
+                    uiButtonStrip->AddChild(actionsConfig.actionAlignment == AdaptiveCards::ActionAlignment::Center ? uiRectangle : uiAction);
                 }
+            }
+
+            if (actionsConfig.actionAlignment == AdaptiveCards::ActionAlignment::Center)
+            {
+                uiButtonStrip->Property("property var rectangleElements", rectangleElements.str());
+                uiButtonStrip->Property("property var actionElements", actionElements.str());
+                uiButtonStrip->Property("onWidthChanged", "horizontalAlign()");
+                uiButtonStrip->Property("onImplicitWidthChanged", "horizontalAlign()");
+                uiButtonStrip->Property("Component.onCompleted", "horizontalAlign()");
+                uiButtonStrip->AddFunctions(getActinSetHorizontalAlignFunc());
             }
 
             // add show card click function
@@ -2498,6 +2527,63 @@ namespace RendererQml
         cardHeightFunction.erase(std::remove(cardHeightFunction.begin(), cardHeightFunction.end(), '\t'), cardHeightFunction.end());
 
         return cardHeightFunction;
+    }
+
+    const std::string RendererQml::AdaptiveCardQmlRenderer::getActinSetHorizontalAlignFunc()
+    {
+        std::string actionSetHorizontalAlignFunc = R"(function horizontalAlign(){
+            var noElementsInCol = [];
+            var colWidths = [];
+            var wid = 0
+            var noElements = 0;
+
+            for(var i=0;i<actionElements.length;i++){
+                let itemWidth = actionElements[i].width + (i == 0 ? 0 : spacing);
+                if(wid + itemWidth <= width){
+                    noElements++;
+                    wid += itemWidth;
+                }
+                else{
+                    noElementsInCol.push(noElements);
+                    colWidths.push(wid);
+                    noElements = 1;
+                    wid = itemWidth;
+                }
+                actionElements[i].anchors.left = undefined;
+                actionElements[i].anchors.right = undefined;
+                actionElements[i].anchors.horizontalCenter = undefined;
+                rectangleElements[i].width = actionElements[i].width;
+            }
+            noElementsInCol.push(noElements);
+            colWidths.push(wid);
+
+            var itemNo = 0;
+            for(i=0;i<noElementsInCol.length;i++){
+                var itemStart = itemNo;
+                var itemEnd = itemNo + noElementsInCol[i] - 1;
+                if(itemStart < 0 || itemEnd < 0){
+                    continue;
+                }
+                itemNo += noElementsInCol[i];
+                if(itemStart === itemEnd){
+                    rectangleElements[itemStart].width = width;
+                    actionElements[itemStart].anchors.horizontalCenter = rectangleElements[itemStart].horizontalCenter;
+                }
+                else{
+                    var extraWidth = (width - colWidths[i])/2;
+
+                    rectangleElements[itemStart].width = actionElements[itemStart].width + extraWidth;
+                    actionElements[itemStart].anchors.right = rectangleElements[itemStart].right;
+
+                    rectangleElements[itemEnd].width = actionElements[itemEnd].width + extraWidth;
+                    actionElements[itemEnd].anchors.left = rectangleElements[itemEnd].left;
+                }
+            }
+        })";
+
+        actionSetHorizontalAlignFunc.erase(std::remove(actionSetHorizontalAlignFunc.begin(), actionSetHorizontalAlignFunc.end(), '\t'), actionSetHorizontalAlignFunc.end());
+
+        return actionSetHorizontalAlignFunc;
     }
 
     std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::GetIconTag(std::shared_ptr<AdaptiveRenderContext> context)

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -290,7 +290,7 @@ namespace RendererQml
                 case AdaptiveCards::ActionAlignment::Right:
                     uiButtonStrip->Property("layoutDirection", "Qt.RightToLeft");
                     break;
-                case AdaptiveCards::ActionAlignment::Center: //TODO: implement for centre alignment
+                case AdaptiveCards::ActionAlignment::Center:
                 default:
                     uiButtonStrip->Property("layoutDirection", "Qt.LeftToRight");
                     break;
@@ -341,7 +341,7 @@ namespace RendererQml
                     uiRectangle->Property("id", Formatter() << uiAction->GetId() << "_rectangle");
                     uiRectangle->Property("height", Formatter() << uiAction->GetId() << ".height");
                     uiRectangle->Property("width", Formatter() << uiAction->GetId() << ".width");
-                    //uiRectangle->Property("Component.onCompleted", "horizontalAlign()");
+                    uiRectangle->Property("color", "'transparent'");
 
                     uiAction->Property("width", "(parent.parent.width > implicitWidth) ? implicitWidth : parent.parent.width");
 

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -108,6 +108,7 @@ namespace RendererQml
 		static const std::string getMinWidthFactSet();
 		static const std::string getSelectLinkFunction();
         static const std::string getCardHeightFunction();
+        static const std::string getActinSetHorizontalAlignFunc();
 
 		template <typename CardElement>
 		static const std::shared_ptr<QmlTag> applyHorizontalBleed(CardElement cardElement, std::shared_ptr<QmlTag> uiContainer, std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Samples/QmlVisualizer/SampleCardJson.h
+++ b/source/qml/Samples/QmlVisualizer/SampleCardJson.h
@@ -4616,6 +4616,125 @@ namespace Samples
         }
     ]
     })";
+
+    const std::string actionSetHorizontalAlign = R"({
+        "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
+        "body": [
+            {
+                "type": "TextBlock",
+                "text": "Left Alignment",
+                "wrap": true
+            },
+            {
+                "type": "ActionSet",
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    }
+                ],
+                "horizontalAlignment": "Left"
+            },
+            {
+                "type": "TextBlock",
+                "text": "Center Alignment",
+                "wrap": true
+            },
+            {
+                "type": "ActionSet",
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    }
+                ],
+                "horizontalAlignment": "Center"
+            },
+            {
+                "type": "TextBlock",
+                "text": "Right Alignment",
+                "wrap": true
+            },
+            {
+                "type": "ActionSet",
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard"
+                        }
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Action.Submit"
+                    }
+                ],
+                "horizontalAlignment": "Right"
+            }
+        ]
+    })";
 }
 
     

--- a/source/qml/Samples/QmlVisualizer/samplecardlist.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardlist.cpp
@@ -39,6 +39,7 @@ SampleCardList::SampleCardList(QObject *parent) : QObject(parent)
 	mCards.append({ QStringLiteral("Bleed Properties"), QString::fromStdString(Samples::card_Bleed) });
 	mCards.append({ QStringLiteral("Input Elements"), QString::fromStdString(Samples::inputElements) });
     mCards.append({ QStringLiteral("Input Validation"), QString::fromStdString(Samples::inputValidation)});
+    mCards.append({ QStringLiteral("Action Set Alignment"), QString::fromStdString(Samples::actionSetHorizontalAlign)});
 
 }
 


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Added Center Alignment for Action set in Horizontal Alignment section for Buttons and cards

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card

![ACL Horizontal Alignment](https://user-images.githubusercontent.com/78958353/170098080-2c5ed1c6-de7e-4153-8739-a757834559dd.gif)
![image](https://user-images.githubusercontent.com/78958353/170198943-7a075a1e-364c-4130-b9d5-cdb8d6580143.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
