### PR TITLE
commit: Fix:: 241471 markdown with bold and italics

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRContentStackView.swift
@@ -324,7 +324,6 @@ extension ACRContentStackView: InputHandlingViewErrorDelegate {
 
 class NoClippingLayer: CALayer {
     override var masksToBounds: Bool {
-        // swiftlint:disable unused_setter_value
         get { return false }
         set { }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
@@ -39,29 +39,33 @@ class TextBlockRendererTests: XCTestCase {
         var textView = renderTextView()
         
         XCTAssertEqual(textView.string, "Hello world!")
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)
+        XCTAssertEqual("CTFontBoldItalicUsage", (textView.attributedString().attributes(at: 0, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)
         
         markdownText = "**Hello world!**"
         textBlock = .make(text: markdownText, textWeight: .lighter)
         textView = renderTextView()
         XCTAssertEqual(textView.string, "Hello world!")
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
+        XCTAssertEqual("CTFontBoldUsage", (textView.attributedString().attributes(at: 0, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)
+        
+        markdownText = "*Hello world!**"
+        textBlock = .make(text: markdownText, textWeight: .lighter)
+        textView = renderTextView()
+        XCTAssertEqual(textView.string, "Hello world!*")
+        XCTAssertEqual("CTFontObliqueUsage", (textView.attributedString().attributes(at: 0, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)
+        
+        markdownText = "This is the _test_ for [Webex](https://www.webex.com)"
+        textBlock = .make(text: markdownText, textWeight: .bolder)
+        textView = renderTextView()
+        XCTAssertEqual(textView.string, "This is the test for Webex")
+        XCTAssertEqual("CTFontBoldUsage", (textView.attributedString().attributes(at: 0, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)
+        XCTAssertEqual("CTFontBoldItalicUsage", (textView.attributedString().attributes(at: 14, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)
         
         // This Case currently Not supported
         /**markdownText = "**_Hello world!_**"
         textBlock = .make(text: markdownText, textWeight: .lighter)
         textView = renderTextView()
         XCTAssertEqual(textView.string, "Hello world!")
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)*/
-        
-        markdownText = "*Hello world!**"
-        textBlock = .make(text: markdownText, textWeight: .lighter)
-        textView = renderTextView()
-        XCTAssertEqual(textView.string, "Hello world!*")
-        XCTAssertFalse(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? true)
-        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)
+        XCTAssertEqual("CTFontBoldUsage", (textView.attributedString().attributes(at: 0, effectiveRange: nil)[.font] as! NSFont).fontDescriptor.fontAttributes[.init("NSCTFontUIUsageAttribute")] as! String)*/
         
         XCTAssertTrue(resourceResolver.textResolverCalled)
     }

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
@@ -33,6 +33,39 @@ class TextBlockRendererTests: XCTestCase {
         XCTAssertTrue(resourceResolver.textResolverCalled)
     }
     
+    func testRendererSetsMultiTraitMarkdownText() {
+        var markdownText = "_Hello world!_"
+        textBlock = .make(text: markdownText, textWeight: .bolder)
+        var textView = renderTextView()
+        
+        XCTAssertEqual(textView.string, "Hello world!")
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)
+        
+        markdownText = "**Hello world!**"
+        textBlock = .make(text: markdownText, textWeight: .lighter)
+        textView = renderTextView()
+        XCTAssertEqual(textView.string, "Hello world!")
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
+        
+        // This Case currently Not supported
+        /**markdownText = "**_Hello world!_**"
+        textBlock = .make(text: markdownText, textWeight: .lighter)
+        textView = renderTextView()
+        XCTAssertEqual(textView.string, "Hello world!")
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false)
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)*/
+        
+        markdownText = "*Hello world!**"
+        textBlock = .make(text: markdownText, textWeight: .lighter)
+        textView = renderTextView()
+        XCTAssertEqual(textView.string, "Hello world!*")
+        XCTAssertFalse(textView.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? true)
+        XCTAssertTrue(textView.font?.fontDescriptor.symbolicTraits.contains(.italic) ?? false)
+        
+        XCTAssertTrue(resourceResolver.textResolverCalled)
+    }
+    
     func testRendererSetsWrap() {
         textBlock = .make(wrap: true)
         


### PR DESCRIPTION
Textblock weights do not work with markdown bold and italics

## Related Issue
The issues fixed with this PR [SPARK-241471](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-241471).

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description

- Fixed Markdown with multi traits (Bold and Italic). 
- Fixed Markdown With Monospaced and multi traits.

Original             	   |  Updated
:-------------------------:|:-------------------------:
<img width="370" alt="Screenshot 2022-05-30 at 11 05 29 AM" src="https://user-images.githubusercontent.com/105660080/170923716-9636f7f8-aba7-47d6-ae16-fdd1d6bfdb17.png">|<img width="365" alt="Screenshot 2022-05-30 at 11 05 01 AM" src="https://user-images.githubusercontent.com/105660080/170923748-589a2436-e347-43ae-8038-7a68e2998a45.png">
<img width="362" alt="Screenshot 2022-06-02 at 4 14 34 PM" src="https://user-images.githubusercontent.com/105660080/171613246-69de864b-ff56-411a-b44f-b0865420aed4.png"> | <img width="359" alt="Screenshot 2022-06-02 at 4 15 37 PM" src="https://user-images.githubusercontent.com/105660080/171613259-e4a596ae-e40a-4789-83ed-f0166528aed3.png">

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
