### PR TITLE
style property of image not working inside imageset

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRCollectionView.swift
@@ -43,6 +43,9 @@ class ACRCollectionView: NSScrollView {
         self.imageViews = imageSet.getImages().map {
             let imageView = ImageSetImageView(imageSize: imageSet.getImageSize(), hostConfig: hostConfig)
             rootView.registerImageHandlingView(imageView, for: $0.getUrl() ?? "")
+            if $0.getStyle() == .person {
+                imageView.isPersonStyle = true
+            }
             return imageView
         }
         super.init(frame: .zero)
@@ -149,6 +152,7 @@ extension ACRCollectionView: NSCollectionViewDelegateFlowLayout {
 class ImageSetImageView: NSImageView, ImageHoldingView {
     let imageSize: ACSImageSize
     let hostConfig: ACSHostConfig
+    var isPersonStyle = false
     
     init(imageSize: ACSImageSize, hostConfig: ACSHostConfig) {
         self.imageSize = imageSize.collectionItemResolvedSize
@@ -158,6 +162,17 @@ class ImageSetImageView: NSImageView, ImageHoldingView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layout() {
+       super.layout()
+       if isPersonStyle, let subview = subviews.first {
+           let maskLayer = CAShapeLayer()
+           maskLayer.path = CGPath(ellipseIn: subview.bounds, transform: nil)
+           subview.wantsLayer = true
+           subview.layer?.mask = maskLayer
+           subview.layer?.masksToBounds = true
+       }
     }
     
     func setImage(_ image: NSImage) {


### PR DESCRIPTION

## Description
ImageSetImageView used inside ImageSet not utilising  "style" property of image

## Sample Card
`{
  "type": "AdaptiveCard",
  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
  "version": "1.2",
  "body": [
    {
      "type": "ImageSet",
      "images": [
        {
          "type": "Image",
          "url": "https://avatar-prod-us-east-2.webexcontent.com/Avtr~V1~1eb65fdf-9643-417f-9974-ad72cae0e10f/V1~c42975ddc87c14d4bcb56dddbf3bc1f553c97731e765be251b954379d814aa65~06dd754dcc954a7e95555098da4eb0e7~1600",
          "width": "70px",
          "size": "Medium",
          "style": "Person"
        },
        {
          "type": "Image",
          "url": "https://avatar-prod-us-east-2.webexcontent.com/Avtr~V1~1eb65fdf-9643-417f-9974-ad72cae0e10f/V1~9e8ce76dbde6eb29e511890bb56dd80372daaacd21843f1c11476b6f6d4acd7d~c5429be8631246549ca780b48f57f70e~1600",
          "width": "70px",
          "size": "Medium",
          "style": "Person"
        }
      ]
    }
  ]
}`

old :
![Screenshot 2022-06-22 at 6 12 45 PM](https://user-images.githubusercontent.com/105856097/175031792-644d5bfe-8354-4a00-9e18-a397a891e14f.png)

new:
![Screenshot 2022-06-22 at 6 07 35 PM](https://user-images.githubusercontent.com/105856097/175031842-6dd0be23-beec-4cf3-85ab-f3a3d2af9715.png)


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
