### PR TITLE
Add debugger log observer for track code

### DIFF
--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -325,7 +325,7 @@ extension RootViewController: AdaptiveCardResourceResolver {
     }
 }
 extension RootViewController: AdaptiveCardSparkDebugObserver {
-    func debugPrint(log msg: Any?) {
+    func adaptiveCardPrint(debugLog msg: Any?) {
         if let userInfoLog = msg as? [String: Any] {
             if let logMsg = userInfoLog["logMsg"] as? String {
                 print(logMsg)

--- a/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
+++ b/source/macos/ADCMacOSVisualizer/ADCMacOSVisualizer/RootViewController.swift
@@ -16,6 +16,7 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
     private var checkButtonConfig: ChoiceSetButtonConfig?
     private var radioButtonConfig: ChoiceSetButtonConfig?
     private var inputFieldConfig: InputFieldConfig = .default
+    private let adaptiveCardStationCenter: AdaptiveCardStationProtocol = AdaptiveCardStationCenter.shared
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,6 +53,15 @@ class RootViewController: NSViewController, NSTableViewDelegate, NSTableViewData
         textView.isAutomaticTextReplacementEnabled = false
         textView.smartInsertDeleteEnabled = false
         cardScrollView.translatesAutoresizingMaskIntoConstraints = true
+        subscribeAdaptiveCardStation()
+    }
+    
+    deinit {
+        adaptiveCardStationCenter.unsubscribeReleasedObservers()
+    }
+    
+    private func subscribeAdaptiveCardStation() {
+        adaptiveCardStationCenter.subscribe(self, for: .debug)
     }
     
     // MARK: Private Methods
@@ -312,5 +322,14 @@ extension RootViewController: AdaptiveCardResourceResolver {
     
     func adaptiveCard(_ adaptiveCard: NSView, attributedStringFor htmlString: String) -> NSAttributedString? {
         return nil
+    }
+}
+extension RootViewController: AdaptiveCardSparkDebugObserver {
+    func debugPrint(log msg: Any?) {
+        if let userInfoLog = msg as? [String: Any] {
+            if let logMsg = userInfoLog["logMsg"] as? String {
+                print(logMsg)
+            }
+        }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/ACRImageProperties.swift
@@ -13,7 +13,7 @@ class ACRImageProperties: NSObject {
     init(element: ACSBaseCardElement, config: ACSHostConfig, parentView: NSView) {
         super.init()
         guard let imageElement = element as? ACSImage else {
-            logError("Element is not of type ACSImage")
+            logError("ACRImageProperties -> Element is not of type ACSImage")
             return
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/SelectActionHandlingProtocol.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/SelectActionHandlingProtocol.swift
@@ -49,7 +49,7 @@ extension SelectActionHandlingProtocol {
         case .toggleVisibility:
             view.setAccessibilityLabel("You are on a Visibility Toggle")
         default:
-            logError("Unhandled Select Action Present in card")
+            logError("SelectActionHandlingProtocol -> Unhandled Select Action Present in card")
         }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Base/Targets.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Base/Targets.swift
@@ -92,7 +92,7 @@ class ActionShowCardTarget: NSObject, TargetHandler {
     
     @objc private func handleButtonAction(_ sender: NSButton) {
         guard let showCardHandler = delegate as? ShowCardTargetHandlerDelegate else {
-            logError("delegate should be of type 'ShowCardHandlerDelegate'")
+            logError("ActionShowCardTarget -> delegate should be of type 'ShowCardHandlerDelegate'")
             return
         }
         showCardHandler.handleShowCardAction(button: sender, showCard: showCard)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionOpenURLRenderer.swift
@@ -6,7 +6,7 @@ class ActionOpenURLRenderer: BaseActionElementRendererProtocol {
     
     func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, targetHandlerDelegate: TargetHandlerDelegate, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let openURLAction = action as? ACSOpenUrlAction else {
-            logError("Element is not of type ACSOpenUrlAction")
+            logError("ActionOpenURLRenderer -> Element is not of type ACSOpenUrlAction")
             return NSView()
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionShowCardRenderer.swift
@@ -6,7 +6,7 @@ class ActionShowCardRenderer: BaseActionElementRendererProtocol {
     
     func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, targetHandlerDelegate: TargetHandlerDelegate, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let showCardAction = action as? ACSShowCardAction else {
-            logError("Element is not of type ACSShowCardAction")
+            logError("ActionShowCardRenderer -> Element is not of type ACSShowCardAction")
             return NSView()
         }
         
@@ -16,7 +16,7 @@ class ActionShowCardRenderer: BaseActionElementRendererProtocol {
         }
 
         guard let showCard = showCardAction.getCard() else {
-            logError("ShowCard object is nil")
+            logError("ActionShowCardRenderer -> ShowCard object is nil")
             return button
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionSubmitRenderer.swift
@@ -6,7 +6,7 @@ class ActionSubmitRenderer: BaseActionElementRendererProtocol {
     
     func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, targetHandlerDelegate: TargetHandlerDelegate, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let submitAction = action as? ACSSubmitAction else {
-            logError("Element is not of type ACSSubmitAction")
+            logError("ActionSubmitRenderer -> Element is not of type ACSSubmitAction")
             return NSView()
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionToggleVisibilityRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionRenderers/ActionToggleVisibilityRenderer.swift
@@ -6,7 +6,7 @@ class ActionToggleVisibilityRenderer: BaseActionElementRendererProtocol {
     
     func render(action: ACSBaseActionElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, targetHandlerDelegate: TargetHandlerDelegate, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let toggleVisibilityAction = action as? ACSToggleVisibilityAction else {
-            logError("Element is not of type ACSToggleVisibilityAction")
+            logError("ActionToggleVisibilityRenderer -> Element is not of type ACSToggleVisibilityAction")
             return NSView()
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ActionSetRenderer.swift
@@ -6,7 +6,7 @@ class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let actionSet = element as? ACSActionSet else {
-            logError("Element is not of type ACSActionSet")
+            logError("ActionSetRenderer -> Element is not of type ACSActionSet")
             return NSView()
         }
         return renderView(actions: actionSet.getActions(), aligned: actionSet.getHorizontalAlignment(), with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs, config: config)
@@ -33,7 +33,7 @@ class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
         let maxAllowedActions = Int(truncating: actionsConfig?.maxActions ?? 10)
         
         if actions.count > maxAllowedActions {
-            logError("WARNING: Some actions were not rendered due to exceeding the maximum number \(maxAllowedActions) actions are allowed")
+            logError("ActionSetRenderer -> WARNING: Some actions were not rendered due to exceeding the maximum number \(maxAllowedActions) actions are allowed")
         }
         
         let orientation: NSUserInterfaceLayoutOrientation
@@ -65,7 +65,7 @@ class ActionSetRenderer: NSObject, BaseCardElementRendererProtocol {
         }
         
         guard !filteredActions.isEmpty else {
-            logError("Actions is empty")
+            logError("ActionSetRenderer -> Actions is empty")
             return NSView()
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/AdaptiveCardRenderer.swift
@@ -37,9 +37,9 @@ class AdaptiveCardRenderer {
         rootView.delegate = actionDelegate
         rootView.resolverDelegate = resourceResolver
         if card.getVersion() == "1.3", !config.supportsSchemeV1_3 {
-            logError("CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
+            logError("Renderer -> CardVersion 1.3 not supported, Card properties of this version and above won't be rendered")
         }
-           
+        logInfo("Renderer -> add ACRView body")
         for (index, element) in card.getBody().enumerated() {
             let isFirstElement = index == 0
             let renderer = RendererManager.shared.renderer(for: element.getType())
@@ -50,6 +50,7 @@ class AdaptiveCardRenderer {
         }
         
         if !card.getActions().isEmpty {
+            logInfo("Renderer -> add ACRView action")
             let view = ActionSetRenderer.shared.renderActionButtons(actions: card.getActions(), with: hostConfig, style: style, rootView: rootView, parentView: rootView, inputs: [], config: config)
             // getting spacing from hostConfig
             if let verticalSpacing = hostConfig.getActions()?.spacing {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/BaseCardElementRenderer.swift
@@ -5,6 +5,7 @@ class BaseCardElementRenderer {
     static let shared = BaseCardElementRenderer()
     
     func updateView(view: NSView, element: ACSBaseCardElement, rootView: ACRView, style: ACSContainerStyle, hostConfig: ACSHostConfig, config: RenderConfig, isfirstElement: Bool) -> NSView {
+        logInfo("BaseCardElementRenderer -> update view")
         let updatedView = ACRContentStackView(style: style, hostConfig: hostConfig, renderConfig: config)
         
         // For Spacing
@@ -54,11 +55,12 @@ class BaseCardElementRenderer {
             return
         }
         guard let collectionView = collectionView as? ACRContentStackView else {
-            logError("Container is not type of ACRContentStackView")
+            logError("BaseCardElementRenderer -> Container is not type of ACRContentStackView")
             return
         }
         // bleed specification requires the object that's asked to be bled to have padding
         if collection.getPadding() {
+            logInfo("BaseCardElementRenderer -> bleed config init")
             let adaptiveBleedDirection = collection.getBleedDirection()
             let direction = ACRBleedDirection(rawValue: adaptiveBleedDirection.rawValue)
             
@@ -103,7 +105,7 @@ class BaseCardElementRenderer {
             
             if collection.getBackgroundImage() != nil {
                 guard let collectionView = collectionView as? ACRColumnView else {
-                    logError("Collection View is not type of ACRColumnView")
+                    logError("BaseCardElementRenderer -> Collection View is not type of ACRColumnView")
                     return
                 }
                 collectionView.bleedBackgroundImage(padding: padding, top: top, bottom: bottom, leading: leading, trailing: trailing, paddingBottom: paddingBottom, with: bottomAnchor)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ChoiceSetInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ChoiceSetInputRenderer.swift
@@ -6,9 +6,10 @@ class ChoiceSetInputRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let choiceSetInput = element as? ACSChoiceSetInput else {
-            logError("Element is not of type ACSChoiceSetInput")
+            logError("ChoiceSetInputRenderer -> element is not of type ACSChoiceSetInput")
             return NSView()
         }
+        logInfo("ChoiceSetInputRenderer -> init")
         if !choiceSetInput.getIsMultiSelect() {
             // style is compact or expanded
             if choiceSetInput.getChoiceSetStyle() == .compact {
@@ -23,6 +24,7 @@ class ChoiceSetInputRenderer: NSObject, BaseCardElementRendererProtocol {
     }
     
     private func choiceSetRenderInternal(choiceSetInput: ACSChoiceSetInput, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, renderConfig: RenderConfig) -> NSView {
+        logInfo("ChoiceSetInputRenderer -> internal render")
         // Parse input default values for multi-select
         let defaultParsedValues = parseChoiceSetInputDefaultValues(value: choiceSetInput.getValue() ?? "")
         let isMultiSelect = choiceSetInput.getIsMultiSelect()
@@ -52,6 +54,7 @@ class ChoiceSetInputRenderer: NSObject, BaseCardElementRendererProtocol {
     }
     
     private func choiceSetCompactRenderInternal (choiceSetInput: ACSChoiceSetInput, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, renderConfig: RenderConfig) -> NSView {
+        logInfo("ChoiceSetInputRenderer -> internal compact render")
         // compact button renderer
         let choiceSetFieldCompactView = ACRChoiceSetCompactView(element: choiceSetInput, renderConfig: renderConfig)
         choiceSetFieldCompactView.autoenablesItems = false

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnRenderer.swift
@@ -6,10 +6,10 @@ class ColumnRenderer: BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let column = element as? ACSColumn else {
-            logError("Element is not of type ACSColumn")
+            logError("ColumnRenderer -> Element is not of type ACSColumn")
             return NSView()
         }
-        
+        logInfo("ColumnRenderer -> init")
         let columnView = ACRColumnView(style: column.getStyle(), parentStyle: style, hostConfig: hostConfig, renderConfig: config, superview: parentView, needsPadding: column.getPadding())
         columnView.translatesAutoresizingMaskIntoConstraints = false
         columnView.setWidth(ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth()))

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -6,9 +6,10 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let columnSet = element as? ACSColumnSet else {
-            logError("Element is not of type ACSColumnSet")
+            logError("ColumnSetRenderer -> element is not of type ACSColumnSet")
             return NSView()
         }
+        logInfo("ColumnSetRenderer -> init")
         let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, renderConfig: config, superview: parentView, needsPadding: columnSet.getPadding())
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
         columnSetView.orientation = .horizontal
@@ -67,7 +68,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             columnSetView.distribution = .gravityAreas
         } else {
             guard columnViews.count == totalColumns else {
-                logError("ArrangedSubViews count mismatch")
+                logError("ColumnSetRenderer -> ArrangedSubViews count mismatch")
                 return columnSetView
             }
             columnSetView.distribution = .fill

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ContainerRenderer.swift
@@ -6,10 +6,10 @@ class ContainerRenderer: BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let container = element as? ACSContainer else {
-            logError("Element is not of type ACSContainer")
+            logError("ContainerRenderer -> Element is not of type ACSContainer")
             return NSView()
         }
-        
+        logInfo("ContainerRenderer -> init")
         let containerView = ACRColumnView(style: container.getStyle(), parentStyle: style, hostConfig: hostConfig, renderConfig: config, superview: rootView, needsPadding: container.getPadding())
         containerView.translatesAutoresizingMaskIntoConstraints = false
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/FactSetRenderer.swift
@@ -6,9 +6,10 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let factSet = element as? ACSFactSet else {
-            logError("Element is not of type ACSFactSet")
+            logError("FactSetRenderer -> element is not of type ACSFactSet")
             return NSView()
         }
+        logInfo("FactSetRenderer -> init")
         let factArray = factSet.getFacts()
         let factsetConfig = hostConfig.getFactSet()
         
@@ -98,7 +99,7 @@ class FactSetRenderer: NSObject, BaseCardElementRendererProtocol {
         for (index, elem) in titleStack.arrangedSubviews.enumerated() {
             let valueArray = valueStack.arrangedSubviews
             guard let titleView = elem as? ACRTextView, let valueView = valueArray[index] as? ACRTextView else {
-                 logError("Element inside FactSetStack is not of type ACRFactTextField")
+                 logError("FactSetRenderer -> Element inside FactSetStack is not of type ACRFactTextField")
                  continue
             }
             titleView.heightAnchor.constraint(equalTo: valueView.heightAnchor).isActive = true

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageRenderer.swift
@@ -6,15 +6,15 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let imageElement = element as? ACSImage else {
-            logError("Element is not of type ACSImage")
+            logError("ImageRenderer -> Element is not of type ACSImage")
             return NSView()
         }
                         
         guard let url = imageElement.getUrl() else {
-            logError("URL is not available")
+            logError("ImageRenderer -> URL is not available")
             return NSView()
         }
-        
+        logInfo("ImageRenderer -> init")
         let imageView: ImageView
         if let dimensions = rootView.getImageDimensions(for: url) {
             let image = NSImage(size: dimensions)
@@ -98,12 +98,12 @@ class ImageRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func configUpdateForImage(image: NSImage?, imageView: NSImageView) {
         guard let superView = imageView.superview as? ACRImageWrappingView, let imageSize = image?.absoluteSize else {
-            logError("superView or image is nil")
+            logError("ImageRenderer -> superView or image is nil")
             return
         }
         
         guard let imageProperties = superView.imageProperties else {
-            logError("imageProperties is null")
+            logError("ImageRenderer -> imageProperties is null")
             return
         }
         imageProperties.updateContentSize(size: imageSize)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ImageSetRenderer.swift
@@ -6,9 +6,10 @@ class ImageSetRenderer: NSObject, BaseCardElementRendererProtocol {
  
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let imageSet = element as? ACSImageSet else {
-            logError("Element is not of type ACSImageSet")
+            logError("ImageSetRenderer -> element is not of type ACSImageSet")
             return NSView()
         }
+        logInfo("ImageSetRenderer -> init")
         let colView = ACRCollectionView(rootView: rootView, imageSet: imageSet, hostConfig: hostConfig)
         colView.translatesAutoresizingMaskIntoConstraints = false
         return colView

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputDateRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputDateRenderer.swift
@@ -6,10 +6,10 @@ open class InputDateRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let dateElement = element as? ACSDateInput else {
-            logError("Element is not of type ACSDateInput")
+            logError("InputDateRenderer -> Element is not of type ACSDateInput")
             return NSView()
         }
-
+        logInfo("InputDateRenderer -> init")
         // setting up basic properties for Input.Date Field
         let inputField: ACRDateField = {
             let view = ACRDateField(isTimeMode: false, config: config, inputElement: dateElement)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputNumberRenderer.swift
@@ -7,10 +7,10 @@ open class InputNumberRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let inputElement = element as? ACSNumberInput else {
-            logError("Element is not of type ACSNumberInput")
+            logError("InputNumberRenderer -> element is not of type ACSNumberInput")
             return NSView()
         }
-        
+        logInfo("InputNumberRenderer -> init")
         // setting up basic properties for Input.Number TextField
         let inputField: ACRNumericTextField = {
             let view = ACRNumericTextField(config: config, inputElement: inputElement)
@@ -42,6 +42,7 @@ open class ACRNumericTextField: NSView, NSTextFieldDelegate {
     private let config: RenderConfig
     
     init(config: RenderConfig, inputElement: ACSBaseInputElement) {
+        logInfo("ACRNumericTextField -> init with render config")
         self.inputElement = inputElement
         self.config = config
         super.init(frame: .zero)
@@ -231,7 +232,7 @@ extension ACRNumericTextField: InputHandlingViewProtocol {
     
     var key: String {
         guard let id = id else {
-            logError("ID must be set on creation")
+            logError("ACRNumericTextField -> ID must be set on creation")
             return ""
         }
         return id

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputTimeRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputTimeRenderer.swift
@@ -6,10 +6,10 @@ open class InputTimeRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let timeElement = element as? ACSTimeInput else {
-            logError("Element is not of type ACSDateInput")
+            logError("InputTimeRenderer -> Element is not of type ACSDateInput")
             return NSView()
         }
-
+        logInfo("InputTimeRenderer -> init")
         // setting up basic properties for Input.Time Field
         let inputField: ACRDateField = {
             let view = ACRDateField(isTimeMode: true, config: config, inputElement: timeElement)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputToggleRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/InputToggleRenderer.swift
@@ -6,9 +6,10 @@ class InputToggleRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let inputToggle = element as? ACSToggleInput else {
-            logError("Element is not of type ACSToggleInput")
+            logError("InputToggleRenderer -> element is not of type ACSToggleInput")
             return NSView()
         }
+        logInfo("InputToggleRenderer -> init")
         // NSMutableAttributedString for the checkbox title
         let attributedString: NSMutableAttributedString
         // NSButton for checkbox

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/RichTextBlockRenderer.swift
@@ -6,10 +6,10 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let richTextBlock = element as? ACSRichTextBlock else {
-            logError("Element is not of type ACSRichTextBlock")
+            logError("RichTextBlockRenderer -> element is not of type ACSRichTextBlock")
             return NSView()
         }
-        
+        logInfo("RichTextBlockRenderer -> init")
         let textView = ACRTextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.isEditable = false
@@ -32,7 +32,7 @@ class RichTextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         // parsing through the inlines
         for inline in richTextBlock.getInlines() {
             guard let textRun = inline as? ACSTextRun else {
-                logError("Not of type ACSTextRun")
+                logError("RichTextBlockRenderer -> Not of type ACSTextRun")
                 continue
             }
                 

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -6,9 +6,10 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let textBlock = element as? ACSTextBlock else {
-            logError("Element is not of type ACSTextBlock")
+            logError("TextblockRenderer -> element is not of type ACSTextBlock")
             return NSView()
         }
+        logInfo("TextblockRenderer -> init")
         let textView = ACRTextView()
         textView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -48,7 +49,6 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         if attributedString.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             // Hide accessibility Element
         }
-        
         return textView
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextInputRenderer.swift
@@ -6,9 +6,10 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
         guard let inputBlock = element as? ACSTextInput else {
-            logError("Element is not of type ACSTextInput")
+            logError("TextInputRenderer -> element is not of type ACSTextInput")
             return NSView()
         }
+        logInfo("TextInputRenderer -> init")
         let stackview: NSStackView = {
             let view = NSStackView()
             view.orientation = .horizontal
@@ -97,8 +98,9 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
     
     private func addInlineButton(parentview: NSStackView, view: NSView, element: ACSTextInput, style: ACSContainerStyle, with hostConfig: ACSHostConfig, rootview: ACRView, config: RenderConfig) {
         guard let action = element.getInlineAction() else {
-            return logError("InlineAction is nil")
+            return logError("TextInputRenderer -> inline action is nil")
         }
+        logInfo("TextInputRenderer -> add inline button")
         let button = ACRButton(actionElement: action, iconPlacement: hostConfig.getActions()?.iconPlacement, buttonConfig: config.buttonConfig, style: .inline)
         if let iconUrl = action.getIconUrl(), !iconUrl.isEmpty {
             rootview.registerImageHandlingView(button, for: iconUrl)
@@ -123,17 +125,19 @@ class TextInputRenderer: NSObject, BaseCardElementRendererProtocol {
         switch action.getType() {
         case .openUrl:
             guard let openURLAction = action as? ACSOpenUrlAction else {
-                logError("Element is not of type ACSOpenUrlAction")
+                logError("TextInputRenderer -> element is not of type ACSOpenUrlAction")
                 return
             }
+            logInfo("TextInputRenderer -> add open Url action")
             let target = ActionOpenURLTarget(element: openURLAction, delegate: rootview)
             target.configureAction(for: button)
             rootview.addTarget(target)
         case .submit:
             guard let submitAction = action as? ACSSubmitAction else {
-                logError("Element is not of type ACSSubmitAction")
+                logError("TextInputRenderer -> element is not of type ACSSubmitAction")
                 return
             }
+            logInfo("TextInputRenderer -> add submit action")
             let target = ActionSubmitTarget(element: submitAction, delegate: rootview)
             target.configureAction(for: button)
             rootview.addTarget(target)
@@ -152,7 +156,7 @@ class ACRTextInputView: ACRTextField, InputHandlingViewProtocol {
     
     var key: String {
         guard let id = idString else {
-            logError("ID must be set on creation")
+            logError("ACRTextInputView -> ID must be set on creation")
             return ""
         }
         return id

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/UnknownElementRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/UnknownElementRenderer.swift
@@ -8,7 +8,7 @@ class UnknownElementRenderer: BaseCardElementRendererProtocol, BaseActionElement
         switch  element.getFallbackType() {
         case .content:
             guard let fallbackElement = element.getFallbackContent() as? ACSBaseCardElement else {
-                logError("Fallback Content is not of type ACSBaseCardElement")
+                logError("UnknownElementRenderer -> Fallback Content is not of type ACSBaseCardElement")
                 return NSView()
             }
             return RendererManager.shared.renderer(for: fallbackElement.getType()).render(element: fallbackElement, with: hostConfig, style: style, rootView: rootView, parentView: parentView, inputs: inputs, config: config)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/BundleUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/BundleUtils.swift
@@ -4,7 +4,7 @@ class BundleUtils {
     static func getImage(_ imageName: String, ofType: String) -> NSImage? {
         let bundle = Bundle(for: self)
         guard let path = bundle.path(forResource: imageName, ofType: ofType) else {
-            logError("AdaptiveCards: Image named '\(imageName)' Not Found")
+            logError("BundleUtils -> AdaptiveCards: Image named '\(imageName)' Not Found")
             return nil
         }
         return NSImage(byReferencing: URL(fileURLWithPath: path))
@@ -13,7 +13,7 @@ class BundleUtils {
     static func loadNibNamed(_ nibName: String, owner: NSView) {
         let bundle = Bundle(for: self)
         guard bundle.loadNibNamed(nibName, owner: owner, topLevelObjects: nil) else {
-            logError("AdaptiveCards: Bundle of '\(nibName)' is nil")
+            logError("BundleUtils -> AdaptiveCards: Bundle of '\(nibName)' is nil")
             return
         }
     }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/HostConfigUtils.swift
@@ -13,7 +13,7 @@ extension ACSHostConfig {
     
     func getBackgroundColor(for containerStyle: ACSContainerStyle) -> NSColor? {
         guard let hexColorCode = getBackgroundColor(containerStyle) else {
-            logError("HexColorCode is nil")
+            logError("ACSHostConfig -> HexColorCode is nil")
             return nil
         }
         return ColorUtils.color(from: hexColorCode)
@@ -21,7 +21,7 @@ extension ACSHostConfig {
     
     func getBorderColor(for containerStyle: ACSContainerStyle) -> NSColor? {
         guard let hexColorCode = getBorderColor(containerStyle) else {
-            logError("HexColorCode is nil")
+            logError("ACSHostConfig -> HexColorCode is nil")
             return nil
         }
         return ColorUtils.color(from: hexColorCode)
@@ -29,7 +29,7 @@ extension ACSHostConfig {
     
     func getBorderThickness(for containerStyle: ACSContainerStyle) -> CGFloat? {
         guard let thickness = getBorderThickness(containerStyle) else {
-            logError("HexColorCode is nil")
+            logError("ACSHostConfig -> HexColorCode is nil")
             return nil
         }
         return CGFloat(exactly: thickness)
@@ -76,7 +76,7 @@ class FontUtils {
             return getSystemFont(for: hostConfig, with: textProperties, fontWeight: fontWeight, italic: isItalic, bold: isBolder)
         }
         guard let customFont = NSFont(name: fontFamily, size: CGFloat(size)) else {
-            logError("Font with fontFamily '\(fontFamily)' not found. Returning system font.")
+            logError("FontUtils -> Font with fontFamily '\(fontFamily)' not found. Returning system font.")
             notFoundFontFamilies.insert(fontFamily)
             return getSystemFont(for: hostConfig, with: textProperties, fontWeight: fontWeight, italic: isItalic, bold: isBolder)
         }
@@ -84,7 +84,7 @@ class FontUtils {
         descriptor.addingAttributes([.face: fontWeights[fontWeight]])
         descriptor = getBoldItalicFontDescriptor(descriptor, italic: isItalic, bold: isBolder)
         guard let finalFont = NSFont(descriptor: descriptor, size: CGFloat(size)) else {
-            logError("Font with fontFamily '\(fontFamily)' not found. Returning system font.")
+            logError("FontUtils -> Font with fontFamily '\(fontFamily)' not found. Returning system font.")
             notFoundFontFamilies.insert(fontFamily)
             return getSystemFont(for: hostConfig, with: textProperties, fontWeight: fontWeight, italic: isItalic, bold: isBolder)
         }
@@ -109,7 +109,7 @@ class FontUtils {
         var fontDescriptor = systemFont.fontDescriptor
         fontDescriptor = getBoldItalicFontDescriptor(fontDescriptor, italic: italic, bold: bold)
         guard let font = NSFont(descriptor: fontDescriptor, size: CGFloat(size)) else {
-            logError("Generating System Italic-bold font failed")
+            logError("FontUtils -> Generating System Italic-bold font failed")
             return systemFont
         }
         return font
@@ -125,7 +125,7 @@ class ColorUtils {
         }
         
         guard hexString.count == 6 || hexString.count == 8 else {
-            logError("Not valid HexCode: \(hexString)")
+            logError("ColorUtils -> Not valid HexCode: \(hexString)")
             return nil
         }
         
@@ -144,7 +144,7 @@ class ColorUtils {
                                blue: CGFloat(rgbValue & 0x000000FF) / 255.0,
                                alpha: CGFloat((rgbValue & 0xFF000000) >> 24) / 255.0)
         default:
-            logError("Not valid HexCode: \(hexString)")
+            logError("ColorUtils -> Not valid HexCode: \(hexString)")
             return nil
         }
     }
@@ -253,7 +253,7 @@ class HostConfigUtils {
         case .extraLarge: spaceAdded = spacingConfig?.extraLargeSpacing ?? 40
         case .padding: spaceAdded = spacingConfig?.paddingSpacing ?? 20
         @unknown default:
-            logError("Unknown padding!")
+            logError("HostConfigUtils -> Unknown padding!")
             spaceAdded = 0
         }
         return spaceAdded

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/LogUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/LogUtils.swift
@@ -22,5 +22,90 @@ private enum LogType {
 private func logPrint(type: LogType, message: [Any], function: String, file: String, line: Int) {
     let fileName = URL(string: file)?.lastPathComponent ?? file
     let joined = message.map { String(describing: $0) }.joined(separator: " ")
-    print("\(type.title): #\(line) \(function) \(fileName): ", joined)
+    /// print("\(type.title): #\(line) \(function) \(fileName): ", joined)
+    SparkCardLogDebuger.print("\(type.title):: #\(line) \(function): \(joined)")
+}
+
+class SparkCardLogDebuger {
+    /// Debug Log For Spark-client
+    /// Spark observer will recived log messages
+    /// - Parameter msg: debug log message
+    class func print(_ msg: Any?) {
+        let userInfoLog = ["logMsg": "AdaptiveCardsDebugLog ## \(msg ?? "")"]
+        AdaptiveCardStationCenter.shared.publishDebug(log: userInfoLog)
+    }
+}
+// MARK: - Spark Log Debugger Observer
+public enum AdaptiveCardObservedType {
+    case debug
+}
+
+public protocol AdaptiveCardObserver: AnyObject {}
+
+public protocol AdaptiveCardSparkDebugObserver: AdaptiveCardObserver {
+    func debugPrint(log msg: Any?)
+}
+
+/// Wrapper class that will hold the weak value of subscribers else VCs are gonna be retained
+/// since they will be stored inside array that lives in Subject singleton object (that is alive through whole application lifecycle)
+public class WeakAdaptiveCardObserver {
+    weak var value: AdaptiveCardObserver?
+    var types: Set<AdaptiveCardObservedType>
+    
+    init(value: AdaptiveCardObserver?, subscribedFor types: [AdaptiveCardObservedType]) {
+        self.value = value
+        self.types = Set(types)
+    }
+}
+
+public protocol AdaptiveCardStationProtocol: AnyObject {
+    func subscribe(_ observer: AdaptiveCardObserver, for types: AdaptiveCardObservedType...)
+    func unsubscribe(_ observer: AdaptiveCardObserver, from type: AdaptiveCardObservedType)
+    func unsubscribe(_ observer: AdaptiveCardObserver)
+    func unsubscribeReleasedObservers() // Used for unsubscribing all observers that are nil
+}
+
+public class AdaptiveCardStationCenter: AdaptiveCardStationProtocol {
+    public static let shared = AdaptiveCardStationCenter()
+    
+    private init() { }
+    
+    private var observers: [WeakAdaptiveCardObserver] = []
+    
+    public func subscribe(_ observer: AdaptiveCardObserver, for types: AdaptiveCardObservedType...) {
+        let existingObserverIndex = observers.firstIndex(where: { $0.value === observer })
+        
+        if let index = existingObserverIndex {
+            types.forEach({ observers[index].types.insert($0) })
+        } else {
+            observers.append(WeakAdaptiveCardObserver(value: observer, subscribedFor: types))
+        }
+        logInfo("Number of subscribers: \(observers.count)")
+    }
+    
+    public func unsubscribe(_ observer: AdaptiveCardObserver, from type: AdaptiveCardObservedType) {
+        guard let index = observers.firstIndex(where: { $0.value === observer }) else { return } // Address comparison
+        observers[index].types.remove(type)
+        logInfo("Number of subscribers: \(observers.count)")
+    }
+    
+    public func unsubscribe(_ observer: AdaptiveCardObserver) {
+        observers = observers.filter({ $0.value !== observer })
+        logInfo("Number of subscribers: \(observers.count)")
+    }
+    
+    // This method has to be called manually on deinit of some observer object
+    public func unsubscribeReleasedObservers() {
+        observers = observers.filter({ $0.value != nil })
+        logInfo("Number of subscribers: \(observers.count)")
+    }
+}
+
+extension AdaptiveCardStationCenter {
+    public func publishDebug(log msg: Any?) {
+        observers.filter({ $0.types.contains(.debug) }).forEach { observer in
+            guard let cardObserver = observer.value as? AdaptiveCardSparkDebugObserver else { return }
+            cardObserver.debugPrint(log: msg)
+        }
+    }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Utils/LogUtils.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Utils/LogUtils.swift
@@ -43,7 +43,7 @@ public enum AdaptiveCardObservedType {
 public protocol AdaptiveCardObserver: AnyObject {}
 
 public protocol AdaptiveCardSparkDebugObserver: AdaptiveCardObserver {
-    func debugPrint(log msg: Any?)
+    func adaptiveCardPrint(debugLog msg: Any?)
 }
 
 /// Wrapper class that will hold the weak value of subscribers else VCs are gonna be retained
@@ -105,7 +105,7 @@ extension AdaptiveCardStationCenter {
     public func publishDebug(log msg: Any?) {
         observers.filter({ $0.types.contains(.debug) }).forEach { observer in
             guard let cardObserver = observer.value as? AdaptiveCardSparkDebugObserver else { return }
-            cardObserver.debugPrint(log: msg)
+            cardObserver.adaptiveCardPrint(debugLog: msg)
         }
     }
 }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRActionSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRActionSetView.swift
@@ -46,6 +46,7 @@ class ACRActionSetView: NSView, ShowCardHandlingView {
         self.buttonSpacing = buttonSpacing
         self.exteriorPadding = exteriorPadding
         super.init(frame: .zero)
+        logInfo("ACRActionSetView -> ")
         initialize()
     }
     
@@ -56,6 +57,7 @@ class ACRActionSetView: NSView, ShowCardHandlingView {
         self.buttonSpacing = 8
         self.exteriorPadding = 0
         super.init(coder: coder)
+        logInfo("ACRActionSetView -> ")
         initialize()
     }
     
@@ -65,6 +67,7 @@ class ACRActionSetView: NSView, ShowCardHandlingView {
         addSubview(stackView)
         addSubview(showCardStackView)
         setupConstraints()
+        logInfo("ACRActionSetView -> ")
     }
     
     override func resizeSubviews(withOldSize oldSize: NSSize) {
@@ -114,7 +117,7 @@ class ACRActionSetView: NSView, ShowCardHandlingView {
     
     private func renderAndAddShowCard(_ card: ACSAdaptiveCard) -> NSView {
         guard let rDelegate = delegate else {
-            logError("Rendering show card failed. Delegate is nil")
+            logError("ACRActionSetView -> Rendering show card failed. Delegate is nil")
             return NSView()
         }
         let cardView = rDelegate.actionSetView(self, renderShowCardFor: card)
@@ -172,7 +175,7 @@ class ACRActionSetView: NSView, ShowCardHandlingView {
 extension ACRActionSetView: ShowCardTargetHandlerDelegate {
     func handleShowCardAction(button: NSButton, showCard: ACSAdaptiveCard) {
         guard let cardId = showCard.getInternalId()?.hash() else {
-            logError("Card InternalID is nil")
+            logError("ACRActionSetView -> Card InternalID is nil")
             return
         }
         

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRButton.swift
@@ -13,18 +13,21 @@ class ACRButton: FlatButton, ImageHoldingView {
         
     override init(frame: NSRect) {
         super.init(frame: frame)
+        logInfo("ACRButton -> ")
         initialize()
         setupButtonStyle(style: .default, buttonConfig: .default)
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        logInfo("ACRButton -> ")
         initialize()
         setupButtonStyle(style: .default, buttonConfig: .default)
     }
     
     init(frame: NSRect = .zero, wantsChevron: Bool = false, wantsIcon: Bool = false, iconPosition: NSControl.ImagePosition = .imageLeft, style: ActionStyle = .default, buttonConfig: ButtonConfig = .default) {
         super.init(frame: frame)
+        logInfo("ACRButton -> init")
         font = buttonConfig.font
         contentInsets = buttonConfig.buttonContentInsets
         // In case the config images for chevron are present, make them config ones, or take the default image
@@ -42,6 +45,7 @@ class ACRButton: FlatButton, ImageHoldingView {
         onAnimationDuration = 0.0
         offAnimationDuration = 0.0
         momentary = !showsChevron
+        logInfo("ACRButton -> ")
     }
     
     override func awakeFromNib() {
@@ -75,6 +79,8 @@ class ACRButton: FlatButton, ImageHoldingView {
             colorConfig = buttonConfig.inline
         }
         
+        logInfo("ACRButton -> ")
+        
         borderColor = colorConfig.borderColor
         selectedBorderColor = colorConfig.selectedBorderColor
         
@@ -90,6 +96,7 @@ class ACRButton: FlatButton, ImageHoldingView {
 
 extension ACRButton {
     convenience init(actionElement: ACSBaseActionElement, iconPlacement: ACSIconPlacement?, buttonConfig: ButtonConfig, style: ActionStyle? = nil) {
+        logInfo("ACRButton -> ")
         let buttonStyle = style ?? ActionStyle(rawValue: actionElement.getStyle() ?? "") ?? .default
         let position = iconPlacement?.imagePosition ?? .imageLeft
         self.init(wantsChevron: actionElement is ACSShowCardAction, wantsIcon: actionElement.hasValidIcon, iconPosition: position, style: buttonStyle, buttonConfig: buttonConfig)

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceButton.swift
@@ -50,6 +50,7 @@ class ACRChoiceButton: NSView, NSTextFieldDelegate, InputHandlingViewProtocol {
         self.buttonTitle = buttonTitle
         
         super.init(frame: .zero)
+        logInfo("ACRChoiceButton -> ")
         button.setButtonType(buttonType == .switch ? .switch : .radio)
         setupViews()
         setupConstraints()
@@ -225,7 +226,7 @@ class ACRChoiceButton: NSView, NSTextFieldDelegate, InputHandlingViewProtocol {
     
     var key: String {
         guard let id = idString else {
-            logError("ID must be set on creation")
+            logError("ACRChoiceButton -> ID must be set on creation")
             return ""
         }
         return id

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRChoiceSetView.swift
@@ -23,6 +23,7 @@ class ACRChoiceSetView: NSView, InputHandlingViewProtocol {
     init(renderConfig: RenderConfig) {
         self.renderConfig = renderConfig
         super.init(frame: .zero)
+        logInfo("ACRChoiceSetView -> ")
         addSubview(stackview)
         setupConstraints()
     }
@@ -88,7 +89,7 @@ class ACRChoiceSetView: NSView, InputHandlingViewProtocol {
     
     var key: String {
         guard let id = idString else {
-            logError("ID must be set on creation")
+            logError("ACRChoiceSetView -> ID must be set on creation")
             return ""
         }
         return id
@@ -174,7 +175,7 @@ class ACRChoiceSetCompactView: NSPopUpButton, InputHandlingViewProtocol {
     
     var key: String {
         guard let id = idString else {
-            logError("ID must be set on creation")
+            logError("ACRChoiceSetCompactView -> ID must be set on creation")
             return ""
         }
         return id

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRDateField.swift
@@ -110,7 +110,7 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
     
     var key: String {
         guard let id = idString else {
-            logError("ID must be set on creation")
+            logError("ACRDateField -> ID must be set on creation")
             return ""
         }
         return id
@@ -140,6 +140,7 @@ class ACRDateField: NSView, InputHandlingViewProtocol {
         self.config = config
         self.inputElement = inputElement
         super.init(frame: .zero)
+        logInfo("ACRDateField -> ")
         setupViews()
         setupConstraints()
         setupPopover()

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRMultilineInputTextView.swift
@@ -23,6 +23,7 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
         self.config = config
         self.inputConfig = config.inputFieldConfig
         super.init(frame: .zero)
+        logInfo("ACRMultilineInputTextView -> ")
         BundleUtils.loadNibNamed("ACRMultilineInputTextView", owner: self)
         setupViews()
         setupConstraints()
@@ -30,6 +31,7 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
     
     convenience init(config: RenderConfig, inputElement: ACSBaseInputElement) {
         self.init(config: config)
+        logInfo("ACRMultilineInputTextView -> ")
         setupInputElementProperties(inputElement: inputElement)
     }
     
@@ -53,6 +55,7 @@ class ACRMultilineInputTextView: NSView, NSTextViewDelegate {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        logInfo("ACRMultilineInputTextView -> ")
         scrollView.wantsLayer = true
         scrollView.focusRingCornerRadius = inputConfig.focusRingCornerRadius
         scrollView.focusRingType = .exterior
@@ -193,7 +196,7 @@ extension ACRMultilineInputTextView: InputHandlingViewProtocol {
     
     var key: String {
         guard let id = id else {
-            logError("ID must be set on creation")
+            logError("ACRMultilineInputTextView -> ID must be set on creation")
             return ""
         }
         return id

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRView.swift
@@ -160,7 +160,7 @@ class ACRView: ACRColumnView {
         var toggledContentStackViews: [(ACRContentStackView, Bool)] = []
         for target in targets {
             guard let id = target.getElementId(), let toggleView = findSubview(with: id) else {
-                logError("Target with ID '\(target.getElementId() ?? "nil")' not found for toggleVisibility.")
+                logError("ACRView -> Target with ID '\(target.getElementId() ?? "nil")' not found for toggleVisibility.")
                 continue
             }
             let oldHiddenValue = toggleView.isHidden
@@ -172,7 +172,7 @@ class ACRView: ACRColumnView {
             case .isVisibleFalse:
                 toggleView.isHidden = true
             @unknown default:
-                logError("Unknown ToggleIsVisible value \(target.getIsVisible())")
+                logError("ACRView -> Unknown ToggleIsVisible value \(target.getIsVisible())")
             }
             if let contentStackView = toggleView as? ACRContentStackView {
                 toggledContentStackViews.append((contentStackView, oldHiddenValue))
@@ -235,7 +235,7 @@ extension ACRView: TargetHandlerDelegate {
 extension ACRView: ImageResourceHandlerView {
     func setImage(_ image: NSImage, for url: String) {
         guard let imageViews = imageViewMap[url] else {
-            logError("No views registered for url '\(url)'")
+            logError("ACRView -> No views registered for url '\(url)'")
             return
         }
         DispatchQueue.main.async {

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/FlatButton.swift
@@ -172,11 +172,13 @@ open class FlatButton: NSButton, CALayerDelegate {
     
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
+        logInfo("FlatButton -> ")
         initialize()
     }
     
     override init(frame: NSRect) {
         super.init(frame: frame)
+        logInfo("FlatButton -> ")
         initialize()
     }
     
@@ -222,6 +224,7 @@ open class FlatButton: NSButton, CALayerDelegate {
         setupImage()
         setupTrackingArea()
         drawsChevron(chevIcon: chevronDownIcon)
+        logInfo("FlatButton -> ")
     }
     
     internal func setupTitle() {


### PR DESCRIPTION
Add debugger log For track code

## Related Issue

- Unable to track debug-logs 

## Description
- We are unable to track debug-logs from the root controller (eg. spark client framework). That is why we have made changes.
- Add debug Observer that used for passing the LogMessage between two different target.
- Within this, developers can extended their own Observer case.

Debugger Sampler Snapshot |
:-------------------------:|
<img width="1646" alt="Screenshot 2022-06-29 at 4 32 48 PM 2" src="https://user-images.githubusercontent.com/105660080/176431308-af894cd9-6452-4950-bedd-50dac1f5f932.png">|


## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
