### PR TITLE
1. removed redundant styling , 2. added flow for tabbing indent case

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -24,6 +24,16 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         
         attributedString.addAttributes([.baselineOffset: (textView.font?.pointSize ?? 0) / 3], range: NSRange(location: 0, length: attributedString.length))
         
+        attributedString.enumerateAttributes(in: attributedString.fullRange, using: { attributes, range, _ in
+            // need to update attributedString paragraphstyle alignment if it is not set in markdownString
+            guard let style = attributes[.paragraphStyle] as? NSMutableParagraphStyle else { return }
+            // headIndent default value is 0.0 , so if it is not updated we can proceed to change alignment
+            if style.headIndent == 0 {
+                style.alignment = ACSHostConfig.getTextBlockAlignment(from: textBlock.getHorizontalAlignment())
+                attributedString.addAttribute(.paragraphStyle, value: style, range: range)
+            }
+        })
+        
         if let colorHex = hostConfig.getForegroundColor(style, color: textBlock.getTextColor(), isSubtle: textBlock.getIsSubtle()), let textColor = ColorUtils.color(from: colorHex) {
             attributedString.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedString.length))
         }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -22,10 +22,7 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         textView.layoutManager?.usesFontLeading = false
         textView.setContentHuggingPriority(.required, for: .vertical)
         
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = ACSHostConfig.getTextBlockAlignment(from: textBlock.getHorizontalAlignment())
-        
-        attributedString.addAttributes([.paragraphStyle: paragraphStyle, .baselineOffset: (textView.font?.pointSize ?? 0) / 3], range: NSRange(location: 0, length: attributedString.length))
+        attributedString.addAttributes([.baselineOffset: (textView.font?.pointSize ?? 0) / 3], range: NSRange(location: 0, length: attributedString.length))
         
         if let colorHex = hostConfig.getForegroundColor(style, color: textBlock.getTextColor(), isSubtle: textBlock.getIsSubtle()), let textColor = ColorUtils.color(from: colorHex) {
             attributedString.addAttributes([.foregroundColor: textColor], range: NSRange(location: 0, length: attributedString.length))


### PR DESCRIPTION
## Description
Markdown indentation was not taking care of tabbing introduced due to ordered list.

Added flow for same.
## Sample Card
`{
            "type": "AdaptiveCard",
            "body": [
              {
                "type": "TextBlock",
                "text": "1. Open the **Cisco AnyConnect Secure Mobility Client** from your Applications folder.\n\n2. Select the closest location. \n\n **Need more guidance?**\n\n[View detailed instructions](https://ontrack-static.cisco.com/Welcome-Mac.pdf) in the Device Portal.",
                "wrap": true
              }
            ],
            "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
            "version": "1.2"
          }`


**old flow**
<img width="575" alt="Screenshot 2022-07-15 at 8 37 45 AM" src="https://user-images.githubusercontent.com/105856097/179143699-03e69f76-f2c1-4da6-bedf-b756a406f176.png">



**new flow**
<img width="589" alt="Screenshot 2022-07-15 at 8 37 31 AM" src="https://user-images.githubusercontent.com/105856097/179143785-9d92f308-0178-4824-a0fb-f627649eec54.png">


## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
