### PR TITLE
setting all column with equal width if any one has width property as auto

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -61,7 +61,12 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
                 columnViews[index].widthAnchor.constraint(equalTo: firstColumn.widthAnchor).isActive = true
             }
             columnSetView.distribution = .fill
-        } else if numberOfAutoItems == totalColumns {
+        } else if numberOfAutoItems > 0 || numberOfAutoItems == totalColumns {
+            let width = ( 350 - ( 10 * ( columnViews.count + 1 ))) / columnViews.count
+            
+            for index in (0 ..< columnViews.count) {
+                columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width)).isActive = true
+            }
             columnSetView.distribution = .gravityAreas
         } else if numberOfStretchItems == 0 && numberOfWeightedItems == 0 {
             columnSetView.distribution = .gravityAreas

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -4,7 +4,7 @@ import AppKit
 class ColumnSetRenderer: BaseCardElementRendererProtocol {
     private struct Constants {
         static let maxCardWidth: Int = 350
-        static let padding: Int = 10
+        static let padding: Int = 12
     }
     static let shared = ColumnSetRenderer()
     
@@ -13,6 +13,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             logError("Element is not of type ACSColumnSet")
             return NSView()
         }
+        var stylePaddingCount = columnSet.getPadding() ? 1 : 0
         let columnSetView = ACRContentStackView(style: columnSet.getStyle(), parentStyle: style, hostConfig: hostConfig, renderConfig: config, superview: parentView, needsPadding: columnSet.getPadding())
         columnSetView.translatesAutoresizingMaskIntoConstraints = false
         columnSetView.orientation = .horizontal
@@ -24,6 +25,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         let totalColumns = columnSet.getColumns().count
         var columnViews: [NSView] = []
         for (index, column) in columnSet.getColumns().enumerated() {
+            stylePaddingCount += column.getPadding() ? 1 : 0
             let width = ColumnWidth(columnWidth: column.getWidth(), pixelWidth: column.getPixelWidth())
             
             if width.isWeighted { numberOfWeightedItems += 1 }
@@ -66,7 +68,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             }
             columnSetView.distribution = .fill
         } else if numberOfAutoItems > 0 || numberOfAutoItems == totalColumns {
-            let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + 1 ))) / columnViews.count
+            let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + stylePaddingCount ))) / columnViews.count
             
             for index in (0 ..< columnViews.count) {
                 let widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -69,7 +69,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + 1 ))) / columnViews.count
             
             for index in (0 ..< columnViews.count) {
-                var widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
+                let widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
                 widthAnchor.priority = .defaultHigh
                 widthAnchor.isActive = true
             }

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -2,6 +2,10 @@ import AdaptiveCards_bridge
 import AppKit
 
 class ColumnSetRenderer: BaseCardElementRendererProtocol {
+    private struct Constants {
+        static let maxCardWidth: Int = 350
+        static let padding: Int = 10
+    }
     static let shared = ColumnSetRenderer()
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
@@ -62,10 +66,12 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             }
             columnSetView.distribution = .fill
         } else if numberOfAutoItems > 0 || numberOfAutoItems == totalColumns {
-            let width = ( 350 - ( 10 * ( columnViews.count + 1 ))) / columnViews.count
+            let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + 1 ))) / columnViews.count
             
             for index in (0 ..< columnViews.count) {
-                columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width)).isActive = true
+                var widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
+                widthAnchor.priority = .defaultHigh
+                widthAnchor.isActive = true
             }
             columnSetView.distribution = .gravityAreas
         } else if numberOfStretchItems == 0 && numberOfWeightedItems == 0 {


### PR DESCRIPTION

## Related Issue
If column has width property as auto, UI not rendering properly.

To fix that, setting all column with equal width if any one has width property as auto



## Sample Card1
`{
   "$schema":"http://adaptivecards.io/schemas/adaptive-card.json",
   "type":"AdaptiveCard",
   "version":"1.2",
   "body":[
      {
         "type":"TextBlock",
         "text":"Actual Alert",
         "wrap":true,
         "spacing":"None",
         "color":"Attention",
         "weight":"Lighter",
         "isSubtle":false,
         "size":"Default"
      },
      {
         "type":"ColumnSet",
         "columns":[
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Input.ChoiceSet",
                     "id":"dropdown",
                     "value":"I'm on it",
                     "choices":[
                        {
                           "title":"I'm on it",
                           "value":"I'm on it"
                        },
                        {
                           "title":"No Action Needed",
                           "value":"No Action Needed"
                        },
                        {
                           "title":"Invalid Alert",
                           "value":"Invalid Alert"
                        },
                        {
                           "title":"Mass",
                           "value":"Mass"
                        }
                     ],
                     "wrap":true,
                     "spacing":"None",
                     "size":"Small"
                  }
               ],
               "style":"Default",
               "bleed":false,
               "spacing":"None"
            },
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Image",
                     "style":"Person",
                     "url":"https://adaptivecards.io/content/cats/1.png",
                     "selectAction":{
                        "type":"Action.OpenUrl",
                        "url":"https://google.com",
                        "title":"Open INC"
                     }
                  }
               ],
               "width":"30px"
            },
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Image",
                     "style":"Person",
                     "url":"https://adaptivecards.io/content/cats/1.png",
                     "selectAction":{
                        "type":"Action.OpenUrl",
                        "url":"https://adaptivecards.io/content/cats/1.png",
                        "title":"Unified Calendar"
                     }
                  }
               ],
               "width":"30px"
            },
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Image",
                     "style":"Person",
                     "url":"https://adaptivecards.io/content/cats/1.png",
                     "selectAction":{
                        "type":"Action.OpenUrl",
                        "url":"https://google.com",
                        "title":"Monitoring Request"
                     }
                  }
               ],
               "width":"30px"
            },
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Image",
                     "style":"Person",
                     "url":"https://adaptivecards.io/content/cats/1.png",
                     "selectAction":{
                        "type":"Action.OpenUrl",
                        "url":"https://google.com",
                        "title":"ACK Stats"
                     }
                  }
               ],
               "width":"30px"
            },
            {
               "type":"Column",
               "items":[
                  {
                     "type":"Image",
                     "style":"Person",
                     "url":"https://adaptivecards.io/content/cats/1.png",
                     "selectAction":{
                        "type":"Action.OpenUrl",
                        "url":"https://google.com",
                        "title":"KB Article"
                     }
                  }
               ],
               "width":"30px"
            }
         ]
      },
      {
         "type":"TextBlock",
         "text":"WebExMsgId",
         "wrap":true,
         "spacing":"None",
         "color":"Accent",
         "weight":"Lighter",
         "isSubtle":true,
         "size":"Small"
      }
   ],
   "actions":[
      {
         "type":"Action.OpenUrl",
         "title":"Details",
         "url":"https://www.google.com"
      },
      {
         "type":"Action.Submit",
         "title":"ACK",
         "data":{
            "id":"ACK",
            "MessageId":"Original message id here",
            "MsgCreated":"11/11/2021",
            "AlertBody":"Actual Alert",
            "Url":"https://www.google.com",
            "Criticality":"warning",
            "Source":"AppD or Splunk",
            "Step":"Actionable_ACK"
         },
         "style":"positive"
      },
      {
         "type":"Action.ShowCard",
         "title":"",
         "horizontalAlignment":"Right",
         "style":"destructive",
         "card":{
            "type":"AdaptiveCard",
            "body":[
               {
                  "type":"TextBlock",
                  "text":"Set Alert Suppression - Start Date/Time [**UTC**]",
                  "wrap":true
               },
               {
                  "type":"ColumnSet",
                  "columns":[
                     {
                        "type":"Column",
                        "width":"auto",
                        "items":[
                           {
                              "type":"Input.Date",
                              "id":"StartDate",
                              "value":""
                           }
                        ]
                     },
                     {
                        "type":"Column",
                        "width":"auto",
                        "items":[
                           {
                              "type":"Input.Time",
                              "id":"StartTime",
                              "value":""
                           }
                        ]
                     }
                  ]
               },
               {
                  "type":"TextBlock",
                  "text":"Duration:",
                  "wrap":true
               },
               {
                  "type":"Input.ChoiceSet",
                  "id":"SnoozeMins",
                  "value":"15",
                  "choices":[
                     {
                        "title":"15 mins",
                        "value":"15"
                     },
                     {
                        "title":"30 mins",
                        "value":"30"
                     },
                     {
                        "title":"60 mins",
                        "value":"60"
                     },
                     {
                        "title":"120 mins",
                        "value":"120"
                     }
                  ],
                  "wrap":true,
                  "spacing":"None",
                  "size":"Small"
               },
               {
                  "type":"TextBlock",
                  "text":"Simlarity:",
                  "wrap":true
               },
               {
                  "type":"Input.ChoiceSet",
                  "id":"SimilarityThold",
                  "value":"0.985",
                  "choices":[
                     {
                        "title":"Low (90%+) - Multiple diffs [Host+BT+Value]",
                        "value":"0.9"
                     },
                     {
                        "title":"Medium (95%+) - Single diff [Host|BT]",
                        "value":"0.95"
                     },
                     {
                        "title":"High (98.5%+) - Diff in [Value] only",
                        "value":"0.985"
                     }
                  ],
                  "wrap":true,
                  "style":"expanded"
               },
               {
                  "type":"TextBlock",
                  "text":"Justification",
                  "wrap":true
               },
               {
                  "type":"Input.Text",
                  "id":"Comment",
                  "placeholder":"Alert supression due to CHANGE#....",
                  "isMultiline":true
               }
            ],
            "actions":[
               {
                  "type":"Action.Submit",
                  "title":"Snooze **ALIKE** Alerts",
                  "data":{
                     "cardType":"input",
                     "id":"SnoozeAlike",
                     "AlertBody":"supp_Alertbody",
                     "MsgId":"supp_MsgId"
                  },
                  "style":"positive"
               },
               {
                  "type":"Action.Submit",
                  "title":"Snooze **ALL** Alerts",
                  "data":{
                     "cardType":"input",
                     "id":"SnoozeAll"
                  },
                  "style":"destructive"
               }
            ],
            "$schema":"http://adaptivecards.io/schemas/adaptive-card.json"
         }
      }
   ]
}`


Screenshots:

Old : 
<img width="438" alt="before - farmer text" src="https://user-images.githubusercontent.com/105856097/183852884-8ef4c920-3e9d-4873-a013-e8e4c63190f6.png">


New:
<img width="436" alt="after - farmer text" src="https://user-images.githubusercontent.com/105856097/183852942-fd0ec950-8307-4919-97eb-dfc7d5e472d6.png">

With Toggle visibility:
![toggle test](https://user-images.githubusercontent.com/105856097/184791111-50738792-151d-48f5-8e23-6caf3a31d1bc.gif)

