### PR TITLE
Card Crash for MultiLine Text Edit 1.3

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -179,6 +179,8 @@ namespace RendererQml
             }
         }
 
+        int cardMinHeight = (int(card->GetMinHeight()) - tempMargin > 0 ) ? (int(card->GetMinHeight()) - tempMargin) : 0;
+
         if (!isChildCard)
         {
             auto clipRectangle = std::make_shared<QmlTag>("Rectangle");
@@ -200,23 +202,23 @@ namespace RendererQml
 
             const auto isChildCardString = isChildCard ? "true" : "false";
             bodyLayout->Property("onImplicitHeightChanged", Formatter() << "{"
-                << context->getCardRootId() << ".generateStretchHeight(children," << int(card->GetMinHeight()) - tempMargin << ");"
+                << context->getCardRootId() << ".generateStretchHeight(children," << cardMinHeight << ");"
                 << "var cardHeight = " << context->getCardRootId() << ".getCardHeight(" << bodyLayout->GetId() << ".children);"
                 << context->getCardRootId() << ".sendCardHeight(cardHeight + 2 * " << context->getCardRootId() << ".margins);"
                 << "}");
         }
         else
         {
-            bodyLayout->Property("onImplicitHeightChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << int(card->GetMinHeight()) - tempMargin << ")}");
+            bodyLayout->Property("onImplicitHeightChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << cardMinHeight << ")}");
         }
 
-		bodyLayout->Property("onImplicitHeightChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << int(card->GetMinHeight()) - tempMargin << ")}");
+		bodyLayout->Property("onImplicitHeightChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << cardMinHeight << ")}");
 
-		bodyLayout->Property("onImplicitWidthChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << int(card->GetMinHeight()) - tempMargin << ")}");
+		bodyLayout->Property("onImplicitWidthChanged", Formatter() << "{" << context->getCardRootId() << ".generateStretchHeight(children," << cardMinHeight << ")}");
 
 		if (card->GetMinHeight() > 0)
 		{
-			rectangle->Property("Layout.minimumHeight", std::to_string(card->GetMinHeight() - tempMargin));
+			rectangle->Property("Layout.minimumHeight", std::to_string(cardMinHeight));
 		}
 
         //Add submit onclick event

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -865,11 +865,6 @@ namespace RendererQml
         uiImage->Property("_visibleRect", image->GetIsVisible() ? "true" : "false");
         uiImage->Property("_actionHoverColor", context->GetRGBColor(context->GetConfig()->GetContainerStyles().emphasisPalette.backgroundColor));
 
-        if (image->GetHeight() == AdaptiveCards::HeightType::Stretch && image->GetPixelHeight() == 0)
-        {
-            uiImage->Property("readonly property bool stretch", "true");
-        }
-
         if (image->GetPixelWidth() != 0 || image->GetPixelHeight() != 0)
         {
             if (image->GetPixelWidth() != 0)

--- a/source/qml/Library/RendererQml/TextInputRender.cpp
+++ b/source/qml/Library/RendererQml/TextInputRender.cpp
@@ -291,14 +291,13 @@ std::shared_ptr<RendererQml::QmlTag> TextInputElement::createMultiLineTextAreaEl
     uiTextInput->Property("wrapMode", "Text.Wrap");
     uiTextInput->Property("selectByMouse", "true");
     uiTextInput->Property("selectedTextColor", "'white'");
-    uiTextInput->Property("topPadding", RendererQml::Formatter() << textConfig.multiLineTextTopPadding);
-    uiTextInput->Property("bottomPadding", RendererQml::Formatter() << textConfig.multiLineTextBottomPadding);
     uiTextInput->Property("color", mContext->GetHexColor(textConfig.textColor));
     uiTextInput->Property("placeholderTextColor", mContext->GetHexColor(textConfig.placeHolderColor));
     uiTextInput->Property("leftPadding", RendererQml::Formatter() << textConfig.textHorizontalPadding);
     uiTextInput->Property("rightPadding", RendererQml::Formatter() << textConfig.textHorizontalPadding);
     uiTextInput->Property("Accessible.role", "Accessible.EditableText");
-    uiTextInput->Property("anchors.fill", "parent");
+    uiTextInput->Property("height", "parent.height");
+    uiTextInput->Property("width", "parent.width");
     uiTextInput->AddFunctions(getAccessibleName(uiTextInput));
 
     if (mTextinput->GetMaxLength() > 0)

--- a/source/qml/Library/RendererQml/TextInputRender.h
+++ b/source/qml/Library/RendererQml/TextInputRender.h
@@ -15,12 +15,15 @@ public:
 
 private:
 	std::string mOriginalElementId{ "" };
+	std::string mLabelId{ "" };
+	std::string mErrorMessageId{ "" };
     std::string mEscapedPlaceHolderString{ "" };
     std::string mEscapedLabelString{ "" };
     std::string mEscapedErrorString{ "" };
     std::string mEscapedValueString{ "" };
 	std::shared_ptr<RendererQml::QmlTag> mTextinputElement;
 	std::shared_ptr<RendererQml::QmlTag> mTextinputColElement;
+	std::shared_ptr<RendererQml::QmlTag> mScrollViewWrapper;
 	std::shared_ptr<RendererQml::QmlTag> mContainer;
 	const std::shared_ptr<AdaptiveCards::TextInput>& mTextinput;
 	const std::shared_ptr<RendererQml::AdaptiveRenderContext>& mContext;


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

- Multiline Text Edit Crash when Stretch Fixed
- Multiline focus Issue Fixed

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

Original             	   |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/78958353/186080175-5e07d1b7-f1f3-4fa3-b414-78659efec669.png) | ![image](https://user-images.githubusercontent.com/78958353/186080208-03d5b6ca-f5d3-4a58-8001-d7ef047ad07e.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
