### PR TITLE
Fixed: [Mac] TextBlock which contains a numbered list does not indent

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/TextBlockRenderer.swift
@@ -22,6 +22,7 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
         textView.layoutManager?.usesFontLeading = false
         textView.setContentHuggingPriority(.required, for: .vertical)
         
+        // NSAttributedString text always sticks to bottom with big lineHeight. so we shifted up from baseline offset by half of its mid point. so text will display in vertically center of frame.
         attributedString.addAttributes([.baselineOffset: (textView.font?.pointSize ?? 0) / 3], range: NSRange(location: 0, length: attributedString.length))
         
         attributedString.enumerateAttributes(in: attributedString.fullRange, using: { attributes, range, _ in
@@ -29,8 +30,9 @@ class TextBlockRenderer: NSObject, BaseCardElementRendererProtocol {
             guard let style = attributes[.paragraphStyle] as? NSMutableParagraphStyle else { return }
             // headIndent default value is 0.0 , so if it is not updated we can proceed to change alignment
             if style.headIndent == 0 {
-                style.alignment = ACSHostConfig.getTextBlockAlignment(from: textBlock.getHorizontalAlignment())
-                attributedString.addAttribute(.paragraphStyle, value: style, range: range)
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.alignment = ACSHostConfig.getTextBlockAlignment(from: textBlock.getHorizontalAlignment())
+                attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
             }
         })
         

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/TextBlockRendererTests.swift
@@ -116,6 +116,15 @@ class TextBlockRendererTests: XCTestCase {
         XCTAssertEqual(textView.backgroundColor, .clear)
     }
     
+    func testListedIndent() {
+        textBlock = .make(text: "1. Open the Cisco AnyConnect Secure Mobility Client from your Applications folder.")
+        let textView = renderTextView()
+        let attributedString = textView.attributedString()
+        guard let paragraphStyle2 = attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle else { return XCTFail() }
+        XCTAssertEqual(paragraphStyle2.headIndent, 56)
+        XCTAssertEqual(textView.string, "\t1\tOpen the Cisco AnyConnect Secure Mobility Client from your Applications folder.")
+    }
+    
     private func renderTextView() -> ACRTextView {
         let rootView = FakeRootView()
         rootView.resolverDelegate = resourceResolver


### PR DESCRIPTION
## Description of changes made

- TextBlock which contains a numbered or bulletins list indent minor changes
- Add Test case

## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
