### PR TITLE
Show Card Compiling Delayed and Height Estimate 

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -23,7 +23,7 @@ namespace RendererQml
 		SetRenderConfig(renderConfig);
 	}
 
-	CardDetails AdaptiveCardQmlRenderer::RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex)
+	CardDetails AdaptiveCardQmlRenderer::RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, const int contentIndex)
 	{
 		std::shared_ptr<RenderedQmlAdaptiveCard> output;
 		auto context = std::make_shared<AdaptiveRenderContext>(GetHostConfig(), GetElementRenderers(), GetRenderConfig());
@@ -533,7 +533,7 @@ namespace RendererQml
     std::shared_ptr<QmlTag> AdaptiveCardQmlRenderer::GetComponent(const std::string& loaderId, const std::shared_ptr<QmlTag>& uiCard)
     {
         auto uiComponent = std::make_shared<QmlTag>("Component");
-        std::string componentId = loaderId + "_component";
+        const auto componentId = loaderId + "_component";
         uiComponent->Property("id", componentId);
 
         const std::string layoutId = Formatter() << componentId << "_component_layout";
@@ -807,7 +807,7 @@ namespace RendererQml
 			uiFactSet->Property("visible", "false");
 		}
 
-        int currentHeight = context->getHeightEstimate();
+        const int currentHeight = context->getHeightEstimate();
         int estimatedFactSetHeight = 0;
 		for (const auto fact : factSet->GetFacts())
 		{

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.cpp
@@ -23,7 +23,7 @@ namespace RendererQml
 		SetRenderConfig(renderConfig);
 	}
 
-	std::pair<std::shared_ptr<RenderedQmlAdaptiveCard>, int> AdaptiveCardQmlRenderer::RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex, int& estimatedHeight)
+	CardDetails AdaptiveCardQmlRenderer::RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex)
 	{
 		std::shared_ptr<RenderedQmlAdaptiveCard> output;
 		auto context = std::make_shared<AdaptiveRenderContext>(GetHostConfig(), GetElementRenderers(), GetRenderConfig());
@@ -40,8 +40,7 @@ namespace RendererQml
 			context->AddWarning(AdaptiveWarning(Code::RenderException, e.what()));
 		}
 
-        estimatedHeight = context->getHeightEstimate();
-		return std::make_pair(output, context->getContentIndex());
+		return CardDetails(*output, context->getContentIndex(), context->getHeightEstimate());
 	}
 
     void AdaptiveCardQmlRenderer::SetObjectTypes()

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -82,7 +82,7 @@ namespace RendererQml
         
     private:
         void SetObjectTypes();
-		static std::shared_ptr<QmlTag> GetComponent(const std::string& componentId, const std::shared_ptr<QmlTag>& uiCard);
+		static std::shared_ptr<QmlTag> GetComponent(const std::string& loaderId, const std::shared_ptr<QmlTag>& uiCard);
 
 		template <typename CardElement>
 		static std::shared_ptr<QmlTag> GetNewColumn(CardElement cardElement, std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -41,7 +41,7 @@ namespace RendererQml
         AdaptiveCardQmlRenderer();
         AdaptiveCardQmlRenderer(std::shared_ptr<AdaptiveCards::HostConfig> hostConfig, std::shared_ptr<AdaptiveCardRenderConfig> renderConfig);
 
-        std::pair<std::shared_ptr<RenderedQmlAdaptiveCard>, int> RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex);
+        std::pair<std::shared_ptr<RenderedQmlAdaptiveCard>, int> RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex, int& estimatedHeight);
         static std::shared_ptr<QmlTag> GetClearIconButton(std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> AdaptiveActionRender(std::shared_ptr<AdaptiveCards::BaseActionElement> adaptiveAction, std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> GetIconTag(std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -35,13 +35,27 @@
 
 namespace RendererQml
 {
+    struct CardDetails
+    {
+        RenderedQmlAdaptiveCard cardOutput;
+        int contentIndex;
+        int estimatedHeight;
+
+        CardDetails(RenderedQmlAdaptiveCard cardOutput, int contentIndex, int estimatedHeight)
+            : cardOutput(cardOutput)
+            , contentIndex(contentIndex)
+            , estimatedHeight(estimatedHeight)
+        {
+        }
+    };
+
     class AdaptiveCardQmlRenderer : public AdaptiveCardsRendererBase<QmlTag, AdaptiveRenderContext>
     {
     public:
         AdaptiveCardQmlRenderer();
         AdaptiveCardQmlRenderer(std::shared_ptr<AdaptiveCards::HostConfig> hostConfig, std::shared_ptr<AdaptiveCardRenderConfig> renderConfig);
 
-        std::pair<std::shared_ptr<RenderedQmlAdaptiveCard>, int> RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex, int& estimatedHeight);
+        CardDetails RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex);
         static std::shared_ptr<QmlTag> GetClearIconButton(std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> AdaptiveActionRender(std::shared_ptr<AdaptiveCards::BaseActionElement> adaptiveAction, std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> GetIconTag(std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -38,8 +38,8 @@ namespace RendererQml
     struct CardDetails
     {
         RenderedQmlAdaptiveCard cardOutput;
-        int contentIndex;
-        int estimatedHeight;
+        const int contentIndex;
+        const int estimatedHeight;
 
         CardDetails(RenderedQmlAdaptiveCard cardOutput, int contentIndex, int estimatedHeight)
             : cardOutput(cardOutput)

--- a/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardQmlRenderer.h
@@ -41,7 +41,7 @@ namespace RendererQml
         const int contentIndex;
         const int estimatedHeight;
 
-        CardDetails(RenderedQmlAdaptiveCard cardOutput, int contentIndex, int estimatedHeight)
+        CardDetails(RenderedQmlAdaptiveCard cardOutput, const int contentIndex, const int estimatedHeight)
             : cardOutput(cardOutput)
             , contentIndex(contentIndex)
             , estimatedHeight(estimatedHeight)
@@ -55,7 +55,7 @@ namespace RendererQml
         AdaptiveCardQmlRenderer();
         AdaptiveCardQmlRenderer(std::shared_ptr<AdaptiveCards::HostConfig> hostConfig, std::shared_ptr<AdaptiveCardRenderConfig> renderConfig);
 
-        CardDetails RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, int contentIndex);
+        CardDetails RenderCard(std::shared_ptr<AdaptiveCards::AdaptiveCard> card, const int contentIndex);
         static std::shared_ptr<QmlTag> GetClearIconButton(std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> AdaptiveActionRender(std::shared_ptr<AdaptiveCards::BaseActionElement> adaptiveAction, std::shared_ptr<AdaptiveRenderContext> context);
         static std::shared_ptr<QmlTag> GetIconTag(std::shared_ptr<AdaptiveRenderContext> context);

--- a/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
@@ -11,6 +11,10 @@ namespace RendererQml
         std::string focusRectangleColor{ "#80FFFFFF" };
         std::string textHighlightBackground{ "#FF092D3B" };
         int cardRadius{ 8 };
+        int cardWidth{ 432 };
+        int averageCharHeight{ 14 };
+        int averageCharWidth{ 6 };
+        int averageSpacing{ 4 };
     };
 
     struct InputFieldConfig

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -438,4 +438,32 @@ namespace RendererQml
     {
         return m_RequiredInputElementsIdList;
     }
+
+    void AdaptiveRenderContext::addHeightEstimate(int height)
+    {
+        m_HeightEstimate += height;
+    }
+
+    void AdaptiveRenderContext::setHeightEstimate(int height)
+    {
+        m_HeightEstimate = height;
+    }
+
+    const int AdaptiveRenderContext::getHeightEstimate()
+    {
+        return m_HeightEstimate;
+    }
+
+    const int RendererQml::AdaptiveRenderContext::getEstimatedTextHeight(std::string text)
+    {
+        auto cardConfig = this->GetRenderConfig()->getCardConfig();
+
+        int height = 0;
+
+        height += ((((int(text.size()) * cardConfig.averageCharWidth) / cardConfig.cardWidth) + 1) * cardConfig.averageCharHeight);
+        height += (int(std::count(text.begin(), text.end(), '\n')) * cardConfig.averageCharHeight);
+        height += cardConfig.averageSpacing;
+
+        return height;
+    }
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.cpp
@@ -439,12 +439,12 @@ namespace RendererQml
         return m_RequiredInputElementsIdList;
     }
 
-    void AdaptiveRenderContext::addHeightEstimate(int height)
+    void AdaptiveRenderContext::addHeightEstimate(const int height)
     {
         m_HeightEstimate += height;
     }
 
-    void AdaptiveRenderContext::setHeightEstimate(int height)
+    void AdaptiveRenderContext::setHeightEstimate(const int height)
     {
         m_HeightEstimate = height;
     }
@@ -454,7 +454,7 @@ namespace RendererQml
         return m_HeightEstimate;
     }
 
-    const int RendererQml::AdaptiveRenderContext::getEstimatedTextHeight(std::string text)
+    const int RendererQml::AdaptiveRenderContext::getEstimatedTextHeight(const std::string text)
     {
         auto cardConfig = this->GetRenderConfig()->getCardConfig();
 

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -101,6 +101,12 @@ namespace RendererQml
         void addToRequiredInputElementsIdList(const std::string& elementId);
         const std::vector<std::string>& getRequiredInputElementsIdList();
 
+        void addHeightEstimate(int height);
+        void setHeightEstimate(int height);
+        const int getHeightEstimate();
+
+        const int getEstimatedTextHeight(std::string text);
+
     private:
         bool m_isShowCardinAction{ false };
         bool m_isShowCardLastBodyElement{ false };
@@ -139,6 +145,7 @@ namespace RendererQml
         int m_FactSetCounter{ 0 };
         int m_TextBlockCounter{ 0 };
         int m_ContentIndex{ 0 };
+        int m_HeightEstimate{ 0 };
 
     };
 }

--- a/source/qml/Library/RendererQml/AdaptiveRenderContext.h
+++ b/source/qml/Library/RendererQml/AdaptiveRenderContext.h
@@ -101,11 +101,11 @@ namespace RendererQml
         void addToRequiredInputElementsIdList(const std::string& elementId);
         const std::vector<std::string>& getRequiredInputElementsIdList();
 
-        void addHeightEstimate(int height);
-        void setHeightEstimate(int height);
+        void addHeightEstimate(const int height);
+        void setHeightEstimate(const int height);
         const int getHeightEstimate();
 
-        const int getEstimatedTextHeight(std::string text);
+        const int getEstimatedTextHeight(const std::string text);
 
     private:
         bool m_isShowCardinAction{ false };

--- a/source/qml/Library/RendererQml/CheckBoxRender.cpp
+++ b/source/qml/Library/RendererQml/CheckBoxRender.cpp
@@ -63,6 +63,7 @@ void CheckBoxElement::initialize()
 
 std::shared_ptr<RendererQml::QmlTag> CheckBoxElement::getContentItem()
 {
+    mContext->addHeightEstimate(mCheckBoxConfig.rowHeight);
     auto contentItem = std::make_shared<RendererQml::QmlTag>("RowLayout");
 
     contentItem->Property("height", RendererQml::Formatter() << mCheckBoxConfig.rowHeight);

--- a/source/qml/Library/RendererQml/ChoiceSetRender.cpp
+++ b/source/qml/Library/RendererQml/ChoiceSetRender.cpp
@@ -114,6 +114,7 @@ void ChoiceSetElement::addInputLabel(bool isRequired)
         if (!mChoiceSetInput->GetLabel().empty())
         {
             const auto choiceSetConfig = mContext->GetRenderConfig()->getInputChoiceSetDropDownConfig();
+            mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mChoiceSetInput->GetLabel()));
             auto label = std::make_shared<RendererQml::QmlTag>("Label");
             label->Property("id", RendererQml::Formatter() << mChoiceSetInput->GetId() << "_label");
             label->Property("wrapMode", "Text.Wrap");

--- a/source/qml/Library/RendererQml/ComboBoxRender.cpp
+++ b/source/qml/Library/RendererQml/ComboBoxRender.cpp
@@ -17,6 +17,7 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getQmlTag()
 
 void ComboBoxElement::initialize()
 {
+    mContext->addHeightEstimate(mChoiceSetConfig.height);
     mComboBox = std::make_shared<RendererQml::QmlTag>("ComboBox");
     mEscapedPlaceHolderString = RendererQml::Utils::getBackQuoteEscapedString(mChoiceSet.placeholder);
 

--- a/source/qml/Library/RendererQml/DateInputRender.cpp
+++ b/source/qml/Library/RendererQml/DateInputRender.cpp
@@ -209,6 +209,7 @@ void DateInputElement::initDateInputField()
 
 void DateInputElement::initDateInputWrapper()
 {
+    mContext->addHeightEstimate(mDateConfig.height);
     mDateInputWrapper = std::make_shared<RendererQml::QmlTag>("Rectangle");
 
     mDateInputWrapper->Property("id", mDateInputWrapperId);
@@ -591,6 +592,7 @@ void DateInputElement::addInputLabel(bool isRequired)
     {
         if (!mDateInput->GetLabel().empty())
         {
+            mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mDateInput->GetLabel()));
             auto label = std::make_shared<RendererQml::QmlTag>("Label");
             label->Property("id", RendererQml::Formatter() << mDateInputColElement->GetId() << "_label");
             label->Property("wrapMode", "Text.Wrap");

--- a/source/qml/Library/RendererQml/NumberInputRender.cpp
+++ b/source/qml/Library/RendererQml/NumberInputRender.cpp
@@ -40,6 +40,7 @@ std::shared_ptr<RendererQml::QmlTag> NumberInputElement::getQmlTag()
 
 void NumberInputElement::initialize()
 {
+    mContext->addHeightEstimate(numberConfig.height);
     const std::string origionalElementId = mInput->GetId();
     mEscapedPlaceHolderString = RendererQml::Utils::getBackQuoteEscapedString(mInput->GetPlaceholder());
     mInput->SetId(mContext->ConvertToValidId(mInput->GetId()));
@@ -244,6 +245,7 @@ void NumberInputElement::createInputLabel()
     {
         if (!mInput->GetLabel().empty())
         {
+            mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mInput->GetLabel()));
             auto label = std::make_shared<RendererQml::QmlTag>("Label");
             label->Property("id", RendererQml::Formatter() << mInput->GetId() << "_label");
             label->Property("wrapMode", "Text.Wrap");

--- a/source/qml/Library/RendererQml/TextInputRender.cpp
+++ b/source/qml/Library/RendererQml/TextInputRender.cpp
@@ -17,6 +17,9 @@ std::shared_ptr<RendererQml::QmlTag> TextInputElement::getQmlTag()
 
 void TextInputElement::initialize()
 {
+    const auto textConfig = mContext->GetRenderConfig()->getInputTextConfig();
+    mContext->addHeightEstimate(mTextinput->GetIsMultiline() ? textConfig.multiLineTextHeight : textConfig.height);
+
     mOriginalElementId = mTextinput->GetId();
     mEscapedPlaceHolderString = RendererQml::Utils::getBackQuoteEscapedString(mTextinput->GetPlaceholder());
     mEscapedValueString = RendererQml::Utils::getBackQuoteEscapedString(mTextinput->GetValue());
@@ -28,7 +31,6 @@ void TextInputElement::initialize()
     }
 
     mTextinput->SetId(mContext->ConvertToValidId(mTextinput->GetId()));
-    const auto textConfig = mContext->GetRenderConfig()->getInputTextConfig();
     mTextinputColElement = std::make_shared<RendererQml::QmlTag>("Column");
     mTextinputColElement->Property("id", mTextinput->GetId());
     mTextinput->SetId(mTextinput->GetId() + "_textField");
@@ -49,6 +51,7 @@ void TextInputElement::initialize()
 
 std::shared_ptr<RendererQml::QmlTag> TextInputElement::createInputTextLabel(bool isRequired)
 {
+    mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mTextinput->GetLabel()));
     const auto textConfig = mContext->GetRenderConfig()->getInputTextConfig();
     auto label = std::make_shared<RendererQml::QmlTag>("Label");
     mLabelId = RendererQml::Formatter() << mTextinputColElement->GetId() << "_label";

--- a/source/qml/Library/RendererQml/TimeInputRender.cpp
+++ b/source/qml/Library/RendererQml/TimeInputRender.cpp
@@ -68,6 +68,7 @@ void TimeInputElement::renderTimeElement()
 
 void TimeInputElement::initTimeInputWrapper()
 {
+    mContext->addHeightEstimate(mTimeInputConfig.height);
     mTimeInputWrapper = std::make_shared<RendererQml::QmlTag>("Rectangle");
     mTimeInputWrapper->Property("id", RendererQml::Formatter() << id << "_wrapper");
     mTimeInputWrapper->Property("width", "parent.width");
@@ -427,6 +428,7 @@ void TimeInputElement::addInputLabel(bool isRequired)
     {
         if (!mTimeInput->GetLabel().empty())
         {
+            mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mTimeInput->GetLabel()));
             auto label = std::make_shared<RendererQml::QmlTag>("Label");
             label->Property("id", RendererQml::Formatter() << mTimeInput->GetId() << "_label");
             label->Property("wrapMode", "Text.Wrap");

--- a/source/qml/Library/RendererQml/ToggleInputRender.cpp
+++ b/source/qml/Library/RendererQml/ToggleInputRender.cpp
@@ -71,6 +71,7 @@ void ToggleInputElement::addInputLabel()
     {
         if (!mToggleInput->GetLabel().empty())
         {
+            mContext->addHeightEstimate(mContext->getEstimatedTextHeight(mToggleInput->GetLabel()));
             const auto choiceSetConfig = mContext->GetRenderConfig()->getInputChoiceSetDropDownConfig();
             auto label = std::make_shared<RendererQml::QmlTag>("Label");
             label->Property("id", RendererQml::Formatter() << mToggleInput->GetId() << "_label");

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -117,8 +117,8 @@ QString SampleCardModel::generateQml(const QString& cardQml)
 
     std::shared_ptr<AdaptiveCards::ParseResult> mainCard = AdaptiveCards::AdaptiveCard::DeserializeFromString(cardQml.toStdString(), "2.0");
     std::map<int, std::string> urls = GetImageUrls(mainCard->GetAdaptiveCard(), std::map<int, std::string>());
-    auto [result, contentIndexes] = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0, estimatedHeight);
-    const auto generatedQml = result->GetResult();
+    CardDetails cardDetails = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0);
+    const auto generatedQml = cardDetails.cardOutput.GetResult();
 	
     //SYNCHRONOUS
     ImageDownloader::clearImageFolder();

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -113,11 +113,10 @@ std::shared_ptr<AdaptiveCards::HostConfig> SampleCardModel::getHostConfig()
 QString SampleCardModel::generateQml(const QString& cardQml)
 {
     std::shared_ptr<int> imgCounter{ 0 };
-    int estimatedHeight = 0;
 
     std::shared_ptr<AdaptiveCards::ParseResult> mainCard = AdaptiveCards::AdaptiveCard::DeserializeFromString(cardQml.toStdString(), "2.0");
     std::map<int, std::string> urls = GetImageUrls(mainCard->GetAdaptiveCard(), std::map<int, std::string>());
-    CardDetails cardDetails = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0);
+    auto cardDetails = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0);
     const auto generatedQml = cardDetails.cardOutput.GetResult();
 	
     //SYNCHRONOUS

--- a/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
+++ b/source/qml/Samples/QmlVisualizer/samplecardmodel.cpp
@@ -113,10 +113,11 @@ std::shared_ptr<AdaptiveCards::HostConfig> SampleCardModel::getHostConfig()
 QString SampleCardModel::generateQml(const QString& cardQml)
 {
     std::shared_ptr<int> imgCounter{ 0 };
+    int estimatedHeight = 0;
 
     std::shared_ptr<AdaptiveCards::ParseResult> mainCard = AdaptiveCards::AdaptiveCard::DeserializeFromString(cardQml.toStdString(), "2.0");
     std::map<int, std::string> urls = GetImageUrls(mainCard->GetAdaptiveCard(), std::map<int, std::string>());
-    auto [result, contentIndexes] = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0);
+    auto [result, contentIndexes] = renderer_ptr->RenderCard(mainCard->GetAdaptiveCard(), 0, estimatedHeight);
     const auto generatedQml = result->GetResult();
 	
     //SYNCHRONOUS


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

- Show card compiling is delayed and it will be compiled only when the users press on the Show button
- Added Height Estimate Calculations for cards

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

![image](https://user-images.githubusercontent.com/78958353/189074146-877e2032-a041-486d-b3ec-d2bb43d425fe.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
