### PR TITLE
width auto elements not rendering properly

### DIFF
--- a/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/xcshareddata/xcschemes/AdaptiveCardsTests.xcscheme
+++ b/source/macos/AdaptiveCards/AdaptiveCards.xcodeproj/xcshareddata/xcschemes/AdaptiveCardsTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "08299E3725AF254000799C66"
+               BuildableName = "AdaptiveCardsTests.xctest"
+               BlueprintName = "AdaptiveCardsTests"
+               ReferencedContainer = "container:AdaptiveCards.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -6,6 +6,8 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
     
     struct Constants {
         static let kFillColumnViewVerticalLayoutConstraintPriority = NSLayoutConstraint.Priority.defaultLow - 1
+        static let maxCardWidth: Int = 350
+        static let padding: Int = 10
     }
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
@@ -46,6 +48,12 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             }
             columnSetView.distribution = .fill
         } else if numberOfAutoItems == totalColumns {
+            let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + 1 ))) / columnViews.count
+            for index in (0 ..< columnViews.count) {
+                let widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
+                widthAnchor.priority = .defaultHigh
+                widthAnchor.isActive = true
+            }
             columnSetView.distribution = .gravityAreas
         } else if numberOfStretchItems == 0 && numberOfWeightedItems == 0 {
             columnSetView.distribution = .gravityAreas

--- a/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Renderers/ColumnSetRenderer.swift
@@ -6,8 +6,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
     
     struct Constants {
         static let kFillColumnViewVerticalLayoutConstraintPriority = NSLayoutConstraint.Priority.defaultLow - 1
-        static let maxCardWidth: Int = 350
-        static let padding: Int = 10
+        static let maxCardWidth: Float = 350.0
     }
     
     func render(element: ACSBaseCardElement, with hostConfig: ACSHostConfig, style: ACSContainerStyle, rootView: ACRView, parentView: NSView, inputs: [BaseInputHandler], config: RenderConfig) -> NSView {
@@ -22,6 +21,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
         var numberOfStretchItems = 0
         var numberOfWeightedItems = 0
         let totalColumns = columnSet.getColumns().count
+        var totalPaddingSpace = Float.zero
         var columnViews: [NSView] = []
         
         for (index, column) in columnSet.getColumns().enumerated() {
@@ -30,7 +30,8 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             if width.isWeighted { numberOfWeightedItems += 1 }
             if width == .stretch { numberOfStretchItems += 1 }
             if width == .auto { numberOfAutoItems += 1 }
-            
+            let requestedSpacing = column.getSpacing()
+            totalPaddingSpace += HostConfigUtils.getSpacing(requestedSpacing, with: hostConfig).floatValue
             let columnView = ColumnRenderer.shared.render(element: column, with: hostConfig, style: columnSet.getStyle(), rootView: rootView, parentView: columnSetView, inputs: [], config: config)
             columnViews.append(columnView)
             updateColumnSetSeparatorAndAlignment(columnView: columnView, column: column, columnSetView: columnSetView, rootView: rootView, columnSet: columnSet, isfirstElement: isfirstElement, hostConfig: hostConfig)
@@ -48,7 +49,7 @@ class ColumnSetRenderer: BaseCardElementRendererProtocol {
             }
             columnSetView.distribution = .fill
         } else if numberOfAutoItems == totalColumns {
-            let width = ( Constants.maxCardWidth - ( Constants.padding * ( columnViews.count + 1 ))) / columnViews.count
+            let width = (Constants.maxCardWidth - totalPaddingSpace) / Float(columnViews.count)
             for index in (0 ..< columnViews.count) {
                 let widthAnchor = columnViews[index].widthAnchor.constraint(equalToConstant: CGFloat(width))
                 widthAnchor.priority = .defaultHigh

--- a/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCards/Views/ACRColumnView.swift
@@ -54,7 +54,7 @@ class ACRColumnView: ACRContentStackView {
     private lazy var backgroundImageViewTrailingConstraint = backgroundImageView.trailingAnchor.constraint(equalTo: trailingAnchor)
     
     private (set) var columnWidth: ColumnWidth = .weighted(1)
-    private lazy var minWidthConstraint: NSLayoutConstraint = {
+    private (set) lazy var minWidthConstraint: NSLayoutConstraint = {
         let constraint = widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.minWidth)
         constraint.priority = .defaultHigh
         return constraint
@@ -118,6 +118,9 @@ class ACRColumnView: ACRContentStackView {
     }
     
     func configureColumnProperties(for view: NSView) {
+        if view is ACRDateField || view is ACRSingleLineInputTextView || view is ACRMultilineInputTextView {
+            minWidthConstraint.constant = 100
+        }
         manageWidth(of: view)
     }
     

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Fakes/FakeInputDate.swift
@@ -92,6 +92,10 @@ class FakeInputDate: ACSDateInput {
     override func setHeight(_ value: ACSHeightType) {
         height = value
     }
+    
+    open override func getType() -> ACSCardElementType {
+        return .dateInput
+    }
 }
 
 extension FakeInputDate {

--- a/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
+++ b/source/macos/AdaptiveCards/AdaptiveCardsTests/Renderers/ColumnRendererTests.swift
@@ -96,6 +96,12 @@ class ColumnRendererTests: XCTestCase {
         XCTAssertEqual(columnView.arrangedSubviews.count, 4)
     }
     
+    func testDateFieldWidth() {
+        column = .make(items: [FakeInputDate.make()])
+        let columnView = renderColumnView()
+        XCTAssertEqual(columnView.minWidthConstraint.constant, 100)
+    }
+    
     private func renderColumnView() -> ACRColumnView {
         let view = columnRenderer.render(element: column, with: hostConfig, style: .default, rootView: FakeRootView(), parentView: NSView(), inputs: [], config: .default)
         


### PR DESCRIPTION
Elements with auto width inside ColumnSet not rendering properly. Issues seems prevalent in input elements (date, time)

Changes done : set the minWidthConstraint for dateField to 100.

Screenshots :

Old :
<img width="378" alt="Screenshot 2022-09-14 at 7 04 14 PM" src="https://user-images.githubusercontent.com/105856097/190174958-2b268129-94f9-4c81-86a0-5acfc244a89d.png">
<img width="397" alt="Screenshot 2022-09-14 at 7 04 33 PM" src="https://user-images.githubusercontent.com/105856097/190174968-47a6ceec-f905-4f87-8dc1-102466a79c75.png">
<img width="384" alt="Screenshot 2022-09-14 at 7 06 41 PM" src="https://user-images.githubusercontent.com/105856097/190174972-cda71b81-b17b-46fb-84b7-5ad9cc6f05e5.png">


New:
<img width="389" alt="Screenshot 2022-09-14 at 6 57 25 PM" src="https://user-images.githubusercontent.com/105856097/190175077-9669ae2a-7424-4340-a47e-a497312fdfd2.png">
<img width="392" alt="Screenshot 2022-09-14 at 6 58 21 PM" src="https://user-images.githubusercontent.com/105856097/190175088-cb57b6cb-6330-4ffc-88a5-098713e5cac7.png">
<img width="388" alt="Screenshot 2022-09-14 at 6 59 47 PM" src="https://user-images.githubusercontent.com/105856097/190175092-4d7841f8-c99b-49c8-bebc-ac60cb927860.png">


