### PR TITLE
Input ChoiceSet Overflow Fixed

### DIFF
--- a/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
+++ b/source/qml/Library/RendererQml/AdaptiveCardRenderConfig.h
@@ -128,6 +128,7 @@ namespace RendererQml
         int dropDownRadius{ 12 };
         int dropDownPadding{ 8 };
         int dropDownHeight{ 216 };
+        int maxDropDownWidth{ 800 };
     };
 
     struct ToggleButtonConfig

--- a/source/qml/Library/RendererQml/ComboBoxRender.cpp
+++ b/source/qml/Library/RendererQml/ComboBoxRender.cpp
@@ -25,6 +25,7 @@ void ComboBoxElement::initialize()
     mComboBox->Property("valueRole", "'value'");
     mComboBox->Property("width", "parent.width");
     mComboBox->Property("height", RendererQml::Formatter() << mChoiceSetConfig.height);
+    mComboBox->Property("property int choiceWidth", "0");
 
     mComboBox->Property("model", getModel(mChoiceSet.choices));
     mComboBox->Property("indicator", getArrowIcon()->ToString());
@@ -105,7 +106,7 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getItemDelegate()
     auto itemDelegateId = mChoiceSet.id + "_itemDelegate";
     auto uiItemDelegate = std::make_shared<RendererQml::QmlTag>("ItemDelegate");
     uiItemDelegate->Property("id", itemDelegateId);
-    uiItemDelegate->Property("width", RendererQml::Formatter() << mComboBox->GetId() << ".width");
+    uiItemDelegate->Property("width", RendererQml::Formatter() << "Math.max(" << mChoiceSet.id << ".choiceWidth, " << mChoiceSet.id << ".width)");
     uiItemDelegate->Property("height", RendererQml::Formatter() << mChoiceSetConfig.dropDownElementHeight);
     uiItemDelegate->Property("verticalPadding", RendererQml::Formatter() << mChoiceSetConfig.dropDownElementVerticalPadding);
     uiItemDelegate->Property("horizontalPadding", RendererQml::Formatter() << mChoiceSetConfig.dropDownElementHorizontalPadding);
@@ -121,18 +122,15 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getItemDelegate()
     uiItemDelegate_Text->Property("text", "modelData.text");
     uiItemDelegate_Text->Property("font.family", fontFamily, true);
     uiItemDelegate_Text->Property("font.pixelSize", RendererQml::Formatter() << mChoiceSetConfig.pixelSize);
-    uiItemDelegate_Text->Property("textFormat", "Text.RichText");
     uiItemDelegate_Text->Property("color", mContext->GetHexColor(mChoiceSetConfig.textColor));
     uiItemDelegate_Text->Property("font.family", fontFamily, true);
+    uiItemDelegate_Text->Property("elide", "Text.ElideRight");
 
-    if (mChoiceSet.choices[0].isWrap)
-    {
-        uiItemDelegate_Text->Property("wrapMode", "Text.Wrap");
-    }
-    else
-    {
-        uiItemDelegate_Text->Property("elide", "Text.ElideRight");
-    }
+    std::ostringstream widthFunc;
+    widthFunc << "onImplicitWidthChanged : {";
+    widthFunc << "var maxWidth = implicitWidth > 800 ? 800 : implicitWidth;";
+    widthFunc << mComboBox->GetId() << ".choiceWidth = Math.max(maxWidth, " << mComboBox->GetId() << ".choiceWidth);}";
+    uiItemDelegate_Text->AddFunctions(widthFunc.str());
 
     uiItemDelegate->Property("contentItem", uiItemDelegate_Text->ToString());
 
@@ -164,7 +162,7 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getPopup()
 
     auto popupTag = std::make_shared<RendererQml::QmlTag>("Popup");
     popupTag->Property("y", RendererQml::Formatter() << mChoiceSet.id << ".height + 5");
-    popupTag->Property("width", RendererQml::Formatter() << mChoiceSet.id << ".width");
+    popupTag->Property("width", RendererQml::Formatter() << "Math.max(" << mChoiceSet.id << ".choiceWidth, " << mChoiceSet.id << ".width)");
     popupTag->Property("padding", RendererQml::Formatter() << mChoiceSetConfig.dropDownPadding);
     popupTag->Property("height", RendererQml::Formatter() << contentListViewId << ".contentHeight + (2 * " << mChoiceSetConfig.dropDownPadding << ")" << " > " << mChoiceSetConfig.dropDownHeight << " ? " << mChoiceSetConfig.dropDownHeight << " :" << contentListViewId << ".contentHeight + ( 2 * " << mChoiceSetConfig.dropDownPadding << ")");
 

--- a/source/qml/Library/RendererQml/ComboBoxRender.cpp
+++ b/source/qml/Library/RendererQml/ComboBoxRender.cpp
@@ -129,7 +129,7 @@ std::shared_ptr<RendererQml::QmlTag> ComboBoxElement::getItemDelegate()
 
     std::ostringstream widthFunc;
     widthFunc << "onImplicitWidthChanged : {";
-    widthFunc << "var maxWidth = implicitWidth > 800 ? 800 : implicitWidth;";
+    widthFunc << "var maxWidth = implicitWidth > " << mChoiceSetConfig.maxDropDownWidth << " ? " << mChoiceSetConfig.maxDropDownWidth << " : implicitWidth;";
     widthFunc << mComboBox->GetId() << ".choiceWidth = Math.max(maxWidth, " << mComboBox->GetId() << ".choiceWidth);}";
     uiItemDelegate_Text->AddFunctions(widthFunc.str());
 


### PR DESCRIPTION
## Related Issue
Please use one of the well-known [github fixes keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to reference
the issues fixed with this PR (eg Fixes #<github issue number>). If an issue doesn't yet exist please create one if reasonable to aid 
in issue tracking.

**NOTE**: For multiple issues resolved by this PR use the corresponding keywords **every time** in a comma-delimited list per the reference
page above.

## Description
Create a [descriptive title and provide all of the relevant details in the description](https://chris.beams.io/posts/git-commit/). 
This information lives with the code and will help future readers (***including yourself***) and will serve as documentation.

At the very least please describe the issue you are addressing, and what your fix entails. 

Input Choice Set dropdown overflow fixed in Adaptive Cards

## Sample Card
If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

Original             	   |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/78958353/190389876-9c1a9bbd-9c9e-462b-b03a-86ca3087d2ea.png) | ![image](https://user-images.githubusercontent.com/78958353/190389906-700aa868-c987-4004-b4f3-4824af7d9f45.png)

## How Verified
How you verified the fix, including one or all of the following: 
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it 
will aid in code reviews or corresponding fixes on other platforms for eg.***
